### PR TITLE
Allow mw-buildcdb to ignore redirects

### DIFF
--- a/mwlib/apps/__init__.py
+++ b/mwlib/apps/__init__.py
@@ -8,9 +8,10 @@ import optparse
 import os
 
 def buildcdb():
-    parser = optparse.OptionParser(usage="%prog --input XMLDUMP --output OUTPUT")
+    parser = optparse.OptionParser(usage="%prog --input XMLDUMP --output OUTPUT [--ignore-redirects]")
     parser.add_option("-i", "--input", help="input file")
     parser.add_option("-o", "--output", help="write output to OUTPUT")
+    parser.add_option("-r", "--ignore-redirects", help="skip redirect pages in input file", action="store_true", dest="redirects")
     options, args = parser.parse_args()
     
     if args:
@@ -19,13 +20,14 @@ def buildcdb():
     
     input = options.input
     output = options.output
+    redirects = options.redirects
 
     if not (input and output):
         parser.error("missing argument.")
         
     from mwlib import cdbwiki
 
-    cdbwiki.BuildWiki(input, output)()
+    cdbwiki.BuildWiki(input, output, ignore_redirects=redirects)()
     open(os.path.join(output, "wikiconf.txt"), "w").write("""
 [wiki]
 type = nucdb

--- a/mwlib/cdbwiki.py
+++ b/mwlib/cdbwiki.py
@@ -71,9 +71,11 @@ class ZCdbReader(cdb.Cdb):
 
 
 class BuildWiki(object):
-    def __init__(self, dumpfile, outputdir, prefix='wiki'):
+    def __init__(self, dumpfile, outputdir, prefix='wiki', ignore_redirects=False):
         if type(dumpfile) in (type(''), type(u'')):
-            self.dumpParser = dumpparser.DumpParser(dumpfile)
+            if ignore_redirects:
+                print "Ignoring redirects."
+            self.dumpParser = dumpparser.DumpParser(dumpfile, ignore_redirects)
         else:
             self.dumpParser = dumpfile
         self.output_path = os.path.join(outputdir, prefix)


### PR DESCRIPTION
I added an --ignore-redirects flag to mw-buildcdb, exposing the ignore_redirects **init** parameter in DumpParser. This allowed me to build a CDB from a dump file, so that when I iterate over all articles I only obtain full pages, not a duplicate of each page under each redirect title (which was resulting in my code doing a lot of unnecessary processing, and throwing off the stats I was trying to accumulate).

Another option would be to somehow flag whether or not a page was a redirect when building the CDB, which you could then check when iterating over the CDB, but this seemed to be the best way to address the issue I was running into that I posted about on the Google Group: http://groups.google.com/group/mwlib/browse_thread/thread/b22682b8da9563a5
