### PR TITLE
Fixes #37

### DIFF
--- a/mwlib/apps/make_nuwiki.py
+++ b/mwlib/apps/make_nuwiki.py
@@ -21,7 +21,10 @@ class start_fetcher(object):
         self.nfo = {}
 
     def get_api(self):
-        api = mwapi.mwapi(self.api_url)
+        if self.username:
+            api = mwapi.mwapi(self.api_url, self.username, self.password)
+        else:
+            api = mwapi.mwapi(self.api_url)
         api.set_limit()
 
         if self.username:

--- a/mwlib/net/sapi.py
+++ b/mwlib/net/sapi.py
@@ -40,10 +40,18 @@ def merge_data(dst, src):
 
 
 class mwapi(object):
-    def __init__(self, apiurl):
+    def __init__(self, apiurl, username=None, password=None):
         self.apiurl = apiurl
         self.baseurl = apiurl  # XXX
-        self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookielib.CookieJar()))
+
+        if username:
+            passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
+            passman.add_password(None, apiurl, username, password)
+            auth_handler = urllib2.HTTPBasicAuthHandler(passman)
+            self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookielib.CookieJar()), auth_handler)
+        else:
+            self.opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cookielib.CookieJar()))
+
         self.edittoken = None
         self.qccount = 0
         self.api_result_limit = conf.get("fetch", "api_result_limit", 500, int)


### PR DESCRIPTION
- In the case where MediaWiki is behind an Apache server that does the authentication the userid/password need to be provided when the connection is opened or else the connection will fail.
