### PR TITLE
accept unconventional redirects

### DIFF
--- a/mwlib/nshandling.py
+++ b/mwlib/nshandling.py
@@ -195,7 +195,7 @@ def get_redirect_matcher(siteinfo, handler=None):
         for m in magicwords:            
             if m['name'] == 'redirect':
                 redirect_str = "(?:" + "|".join([re.escape(x) for x in m['aliases']]) + ")"
-    redirect_rex = re.compile(r'^%s:?\s*?\[\[(?P<redirect>.*?)\]\]' % redirect_str, re.IGNORECASE)
+    redirect_rex = re.compile(r'^[ \t\n\r\0\x0B]*%s\s*:?\s*?\[\[(?P<redirect>.*?)\]\]' % redirect_str, re.IGNORECASE)
 
     if handler is None:
         handler =  nshandler(siteinfo)


### PR DESCRIPTION
I have modified nshandling.py to get unconventional redirects recognized as such. 
Now these redirects may contain whitespace-like characters at the beginning
(e.g., "
#REDIRECT [[Foo]]"), or whitespace before an optional colon (e.g., "#REDIRECT : [[Foo]]").

For more information, see:
https://git.wikimedia.org/blob/mediawiki%2Fcore.git/ec02aba4c0e870f97c3ae8d237555c4b16f30750/includes%2Fcontent%2FWikitextContent.php#L188