### PR TITLE
BigQuery-first image description lookup for Wikipedia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cache
 notes.txt
 launch.json
 *.php.bak
+
+# Added by upp-doctor (doctor setup)
+.claude/agent-memory/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -518,6 +518,7 @@ include src/qs/slave.py
 include tasks.md
 include tests/conftest.py
 include tests/mwlib/apps/test_buildzip.py
+include tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
 include tests/mwlib/canthus.mb.json
 include tests/mwlib/core/test_authors.py
 include tests/mwlib/core/test_metabook.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,6 +30,7 @@ include docs/metabook.rst
 include docs/renderserver.rst
 include docs/rlwriter.rst
 include docs/writers.rst
+include feature_planning/bigquery-image-description-lookup.md
 include mediawiki/.gitkeep
 include mw-post
 include mwlib/_uscan.cc
@@ -51,6 +52,7 @@ include setup.py
 include src/mwlib/apps/__init__.py
 include src/mwlib/apps/buildzip.py
 include src/mwlib/apps/executor.py
+include src/mwlib/apps/fetch_wikimedia_snapshot.py
 include src/mwlib/apps/make_nuwiki.py
 include src/mwlib/apps/render.py
 include src/mwlib/apps/utils.py
@@ -76,6 +78,7 @@ include src/mwlib/extensions/timeline.py
 include src/mwlib/network/__init__.py
 include src/mwlib/network/api.py
 include src/mwlib/network/auth.py
+include src/mwlib/network/bigquery_lookup.py
 include src/mwlib/network/client.py
 include src/mwlib/network/fetch.py
 include src/mwlib/network/fetch_siteinfo.py
@@ -520,6 +523,7 @@ include tests/mwlib/core/test_authors.py
 include tests/mwlib/core/test_metabook.py
 include tests/mwlib/kolumne.mb.json
 include tests/mwlib/memeater.py
+include tests/mwlib/network/test_bigquery_lookup.py
 include tests/mwlib/network/test_fetch.py
 include tests/mwlib/network/test_fetch_siteinfo.py
 include tests/mwlib/network/test_http_client.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -50,7 +50,6 @@ include setup.cfg
 include setup.py
 include src/mwlib/apps/__init__.py
 include src/mwlib/apps/buildzip.py
-include src/mwlib/apps/buildzip2.py
 include src/mwlib/apps/executor.py
 include src/mwlib/apps/make_nuwiki.py
 include src/mwlib/apps/render.py

--- a/README.md
+++ b/README.md
@@ -133,10 +133,23 @@ The data originates from the [Wikimedia Enterprise API](https://enterprise.wikim
 
 #### Prerequisites
 
-Install the optional BigQuery dependency:
+The BigQuery client (and the `wme-ingest` CLI that loads snapshots into it)
+is shipped behind the `bigquery` extra so default installs stay slim. Install
+it via the extra rather than pinning `google-cloud-bigquery` directly:
+
 ```bash
-uv pip install "google-cloud-bigquery>=3.0"
+# pip
+pip install "mwlib[bigquery]"
+
+# uv (project install)
+uv pip install "mwlib[bigquery]"
+
+# uv (developer checkout)
+uv sync --extra bigquery
 ```
+
+The `bigquery` extra is also pulled in by the `dev` dependency group, so
+`uv sync` (default groups) installs it for development and test runs.
 
 Set up GCP authentication by pointing to a service account JSON file:
 ```shell

--- a/README.md
+++ b/README.md
@@ -118,6 +118,85 @@ export MWLIB_OAUTH2_CLIENT_SECRET="your_client_secret"
 export MWLIB_OAUTH2_ENABLED="True"
 ```
 
+### BigQuery Lookup for Image Description Pages
+
+mwlib can use Google BigQuery to look up image description pages (namespace 6) instead of fetching them from the remote MediaWiki API. This significantly reduces the number of API requests and bypasses Wikipedia rate limits for configured domains.
+
+The data originates from the [Wikimedia Enterprise API](https://enterprise.wikimedia.com/docs/snapshot/) snapshot endpoint, which provides Wikipedia page data as NDJSON files. These snapshots are loaded into a BigQuery table containing pre-extracted metadata: templates (used for license checking), image dimensions, content URLs, and license information.
+
+#### How it works
+
+1. During ZIP creation (`mw-zip`), image description page titles for configured domains (default: `en.wikipedia.org`) are batched and queried from BigQuery.
+2. For pages found in BigQuery, templates are stored locally and an early license check is performed — images that fail the license filter are never downloaded.
+3. Pages not found in BigQuery fall back to the remote MediaWiki API.
+4. Non-configured domains (e.g., Commons) always use the remote API.
+
+#### Prerequisites
+
+Install the optional BigQuery dependency:
+```bash
+uv pip install "google-cloud-bigquery>=3.0"
+```
+
+Set up GCP authentication by pointing to a service account JSON file:
+```shell
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+```
+
+#### BigQuery Configuration Options
+
+| Config File Option   | Environment Variable         | Default             | Description                                        |
+|----------------------|------------------------------|---------------------|----------------------------------------------------|
+| bigquery.enabled     | MWLIB_BIGQUERY_ENABLED       | false               | Master switch to enable BigQuery lookups            |
+| bigquery.project     | MWLIB_BIGQUERY_PROJECT       | _(required)_        | GCP project ID                                     |
+| bigquery.dataset     | MWLIB_BIGQUERY_DATASET       | wme_snapshots       | BigQuery dataset name                              |
+| bigquery.table       | MWLIB_BIGQUERY_TABLE         | file_pages          | BigQuery table name                                |
+| bigquery.timeout     | MWLIB_BIGQUERY_TIMEOUT       | 30                  | Query timeout in seconds                           |
+| bigquery.domains     | MWLIB_BIGQUERY_DOMAINS       | en.wikipedia.org    | Comma-separated domains to route through BigQuery  |
+
+Example environment variable configuration:
+```shell
+export MWLIB_BIGQUERY_ENABLED="true"
+export MWLIB_BIGQUERY_PROJECT="my-gcp-project"
+export MWLIB_BIGQUERY_DATASET="wikipedia"
+export MWLIB_BIGQUERY_TABLE="file_pages"
+export MWLIB_BIGQUERY_DOMAINS="en.wikipedia.org"
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+```
+
+Or in a configuration file (mwlib.ini):
+```ini
+[bigquery]
+enabled=true
+project=my-gcp-project
+dataset=wikipedia
+table=file_pages
+domains=en.wikipedia.org
+```
+
+When BigQuery is disabled or unavailable (missing credentials, network error, etc.), mwlib falls back to the remote API automatically with no change in behavior.
+
+#### Loading Data into BigQuery
+
+Use the `wme-ingest` command to download a Wikimedia Enterprise namespace 6 snapshot and load it into BigQuery:
+
+```bash
+# Full pipeline: download snapshot + load into BigQuery
+wme-ingest --project my-gcp-project --dataset wikipedia
+
+# Load from an already-downloaded tarball
+wme-ingest -i /path/to/enwiki_ns6.tar.gz --project my-gcp-project --dataset wikipedia
+
+# List available snapshots
+wme-ingest --list
+```
+
+This requires Wikimedia Enterprise API credentials:
+```shell
+export WME_USERNAME="your-username"
+export WME_PASSWORD="your-password"
+```
+
 ## Docker Compose Setup
 For users interested in setting up mwlib using Docker Compose, detailed instructions are available at [Docker Compose documentation](https://docs.docker.com/compose/).
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,89 @@
+# Release Notes for mwlib 0.18.2
+
+## What's New in 0.18.2
+
+### BigQuery Lookup for Image Description Pages
+- **BigQuery-first lookup:** Image description pages (namespace 6) for configured Wikipedia domains are now batch-queried from Google BigQuery instead of fetching from the remote MediaWiki API. This significantly reduces API requests and bypasses Wikipedia rate limits.
+- **Early license checking at fetch time:** Templates from BigQuery are checked against the license database before image downloads are scheduled. Images that fail the license filter (e.g., nonfree album covers) are never downloaded, saving bandwidth and time.
+- **Deferred image downloads:** For BigQuery-eligible domains, image downloads are deferred until the license check completes. Only images that pass the filter are downloaded.
+- **Configurable domains:** The set of BigQuery-backed domains is fully configurable via `MWLIB_BIGQUERY_DOMAINS` (default: `en.wikipedia.org`). Non-configured domains continue to use the remote API.
+- **Graceful fallback:** If BigQuery is unavailable, misconfigured, or missing data for specific pages, all requests fall back to the remote MediaWiki API automatically.
+- **New `templates.db` storage:** Pre-extracted templates from BigQuery are stored in a new `templates.db` SqliteDict, which is checked at render time before falling back to wikitext parsing.
+- **WME ingestion CLI (`wme-ingest`):** New command-line tool for downloading Wikimedia Enterprise namespace 6 snapshots and loading them into BigQuery.
+
+### Configuration
+
+All BigQuery settings are configurable via environment variables or `mwlib.ini`:
+
+| Environment Variable         | Default          | Description                                       |
+|------------------------------|------------------|---------------------------------------------------|
+| MWLIB_BIGQUERY_ENABLED       | false            | Master switch to enable BigQuery lookups           |
+| MWLIB_BIGQUERY_PROJECT       | _(required)_     | GCP project ID                                    |
+| MWLIB_BIGQUERY_DATASET       | wme_snapshots    | BigQuery dataset name                             |
+| MWLIB_BIGQUERY_TABLE         | file_pages       | BigQuery table name                               |
+| MWLIB_BIGQUERY_TIMEOUT       | 30               | Query timeout in seconds                          |
+| MWLIB_BIGQUERY_DOMAINS       | en.wikipedia.org | Comma-separated domains to route through BigQuery |
+
+---
+
+# Release Notes for mwlib 0.18.1
+
+## What's New in 0.18.1
+
+### Domain-Scoped Rate Limiting
+- **Per-domain rate limiting:** API requests are now rate-limited per domain using a token-bucket algorithm, preventing excessive requests to any single MediaWiki instance. Configurable via `MWLIB_FETCH_MAX_REQUESTS_PER_SECOND`.
+- **Download rate limiting:** Image downloads are also subject to per-domain rate limiting, separate from API request limits.
+- **Retry with exponential backoff:** Both `MwApi._fetch` and `download_to_file` now implement retry with exponential backoff and jitter for transient errors (HTTP 429, 5xx, timeouts).
+- **Improved error classification:** Network errors are classified by type (http, url, protocol, timeout) with per-type retry decisions — permanent errors (404) are not retried.
+- **Configurable retry policies:** Retry count, backoff factor, and max delay are configurable via the `[fetch]` config section.
+
+---
+
+# Release Notes for mwlib 0.18.0
+
+## What's New in 0.18.0
+
+### Project Structure Refactoring
+- **Modular package layout:** The codebase has been reorganized into well-defined packages: `mwlib/core/`, `mwlib/parser/`, `mwlib/network/`, `mwlib/rendering/`, `mwlib/writers/`, `mwlib/utils/`, `mwlib/extensions/`, and `mwlib/apps/`.
+- **Standardized import paths:** All import paths have been updated to reflect the new package structure.
+- **Entry point trampoline:** Introduced `main_trampoline.py` for CLI entry points, replacing monkey patching in `mwlib.apps` initialization.
+
+### Networking & HTTP
+- **HTTP client manager:** New `HttpClientManager` singleton with support for both standard and OAuth2 clients, HTTP/2 auto-detection, and connection pool management.
+- **httpx migration:** `MwApi` refactored to use `httpx` for HTTP requests, with support for HTTP/2 and OAuth2 client_credentials flow.
+- **OAuth2 support:** Built-in OAuth2 authentication for MediaWiki APIs that require it, with token lifecycle management and exponential backoff on failures.
+- **Batch contributor lookup:** Contributor API calls are batched for efficiency.
+
+### Build System & Dependencies
+- **uv package manager:** Replaced `pip` with `uv pip` throughout the build system for faster dependency resolution.
+- **python-dotenv integration:** Environment variables are now loaded from `.env` files automatically.
+- **Cython 3.1.2+:** Upgraded Cython with Python 3.8+ compatibility updates for templated nodes and scanner.
+
+### ZIP Creation (`buildzip`)
+- **Modernized buildzip:** Consolidated `buildzip` and `buildzip2` into a single implementation with simplified `make_nuwiki` callback handling.
+- **File extension filtering:** Added `skip_ext` support to exclude files by extension during ZIP creation.
+- **Higher default image size:** Increased default thumbnail size to 1280px to match Wikipedia's largest thumbnail size.
+
+### PDF Writer
+- **RlWriter improvements:** Consistent attribute naming for figure dimensions, improved terminology, and better debug handling.
+- **RTL text fix:** Fixed right-to-left text alignment handling in `text_style` and `heading_style`.
+- **Refactored pdfstyles:** Cleaner styling functions and McCabe complexity compliance.
+
+### Code Quality
+- **Ruff linting:** Applied ruff across the entire codebase with rules for complexity (C90), pydocstyle (D), pycodestyle (E), pyflakes (F), isort (I), and flake8-simplify (SIM).
+- **Standardized logging:** Consistent logging levels and improved file handling in utility modules.
+- **Image path resolution:** Improved fallback handling for image paths in `nuwiki.py`.
+
+### Testing
+- **New test suites:** Added unit tests for `fetch_siteinfo`, `download_to_file`, HTTP client manager, OAuth2 token handling, and rate limiting.
+- **Integration test marker:** Slow RL writer tests are now marked with `@pytest.mark.integration` and excluded from default test runs.
+
+## Upgrading to 0.18.0
+
+mwlib 0.18.0 requires Python 3.11 or 3.12. The package structure has changed significantly — update any direct imports from `mwlib.*` to the new paths (e.g., `mwlib.nuwiki` → `mwlib.core.nuwiki`).
+
+---
+
 # Release Notes for mwlib 0.17.0
 
 We're thrilled to announce the release of mwlib version 0.17.0, a significant step forward in our journey, primarily focused on transitioning from Python 2 to Python 3. This release brings enhanced code quality, improved scalability, and performance optimizations.

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,18 @@ Changelog
 
 mwlib
 ==========================
+2026-05-02 mwlib 0.18.3
+------------------------
+- ``wme-ingest`` learns ``--namespace 0`` for the article-HTML snapshot used by the page-count estimator, alongside the existing namespace-6 (file_pages) sync. Lean NS0 schema (``name`` / ``identifier`` / ``date_modified`` / ``article_body_html``) keeps BigQuery storage proportional to what the estimator actually consumes.
+- ``wme-ingest`` extracts NDJSON members one at a time into a private temp directory, capping peak local disk at "tarball + one extracted NDJSON" and avoiding overwrites of pre-existing files in the tarball's parent. Tar members are also restricted to regular files (no symlinks/hardlinks/devices).
+- ``wme-ingest`` validates ``project`` / ``dataset`` / ``table`` identifiers before they're interpolated into raw SQL.
+- BigQuery image-lookup hardening: hostname-exact domain routing, exact-match row filtering, credential-fingerprinted client cache + token cache, locked singleton + locked client cache, prefix-match ``invalidate_client``.
+- Fail-closed defaults for the BigQuery path: malformed templates rerouted to the remote-API fallback; misses or hits with no remote-API discovery drop the deferred image download (no shipping images without license/attribution data); externally-managed tables fail loudly when missing rather than silently bootstrapping.
+- ``MwApi`` Basic Auth is per-instance (no longer leaks across MwApis sharing an origin); ``RateLimiter`` and retry backoff use ``gevent.sleep`` to cooperate with the gevent hub; ``request_counter`` is per-instance.
+- ``LicenseChecker`` exposes ``decide_from_template_names`` so fetch-time and render-time license policy stay in lockstep.
+- ``nuwiki.Adapt.get_contributors`` reads ``authors.db`` when no description page is on disk (BigQuery shortcut), so BQ-backed images render with attribution.
+- Optional ``mwlib[bigquery]`` install extra; default installs stay slim. ``requests`` declared as a direct dependency.
+
 2026-04-28 mwlib 0.18.2
 ------------------------
 - Allow DEFAULTSORT to accept optional arguments

--- a/changelog.rst
+++ b/changelog.rst
@@ -4,6 +4,58 @@ Changelog
 
 mwlib
 ==========================
+2026-04-28 mwlib 0.18.2
+------------------------
+- Allow DEFAULTSORT to accept optional arguments
+
+2026-04-28 mwlib 0.18.1
+------------------------
+- Add WME ingestion script (wme-ingest) for loading Wikimedia Enterprise snapshots into BigQuery
+
+2026-04-28 mwlib 0.18.0
+------------------------
+- Add BigQuery-first lookup for image description pages
+- Add BigQuery configuration section and optional google-cloud-bigquery dependency
+- Add domain-scoped rate limiting in sapi.py (fetch.max_requests_per_second)
+- Improve retry/backoff handling in sapi.py and http_client.py
+- Add OAuth2 client_credentials support
+- Add HTTP/2 support via httpx
+- Require Python 3.11 or 3.12
+- Replace setup.py with pyproject.toml; use uv for package management
+- Remove buildzip2.py; unify buildzip implementation
+- Update Cython template evaluation for Python 3.11+/Cython 3.2.4
+- Mark slow rl tests with @pytest.mark.integration
+
+2023-12-15 mwlib 0.17.0.post1
+------------------------------
+- Post-release packaging fix (no functional changes)
+
+2023-12-10 mwlib 0.17.0
+------------------------
+- Complete migration to Python 3; Python 2 is no longer supported
+- Project structure refactored: source code moved to ``src/`` directory
+- Python 3 compatibility fixes throughout the codebase (parser, scanner, templates)
+- Fix ``_uscan.re`` Python 3 compatibility
+- Run ``modernize`` script across all modules
+- Code cleanup and linter integration (ruff, bandit)
+- Upgrade dependencies; switch to ``pip-compile-multi`` for requirements management
+- Add Docker Compose setup examples
+- Add Pillow 6.2.1 and update requirements
+- Fix deprecated warnings in tests
+- Fix bugs in EasyTimeline.pl
+- Migrate build system to ``pyproject.toml``
+
+2018-04-24 mwlib 0.16.1
+------------------------
+- Fix handling of missing imagelink in imagemap
+
+2018-04-24 mwlib 0.16.0
+------------------------
+- Code cleanup with autopep8
+- Add requirements file and split test requirements
+- Fix HTTPS in test URLs
+- Use named PyPI server for package uploads
+
 2016-02-18 mwlib 0.15.16
 ------------------------
 - ignore hatnote

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -4,18 +4,16 @@ Getting started
 mwlib provides a library for parsing MediaWiki articles and
 converting them to different output formats.
 
-The collection extension is a MediaWiki extensions enabling users to
+The collection extension is a MediaWiki extension enabling users to
 collect articles and generate PDF files from those.
 
-Both components are used by wikipedia's 'Print/export' feature.
-
-If you're running a low-traffic public mediawiki installation, you
-only have to install the collection extension. You'll have to use the
-public render server run by pediapress GmbH. Please read
-:doc:`collection`.
+mwlib is used by some MediaWiki installations for PDF export.
 
 If you need to run your own render server instance, you'll have to
-install mwlib and mwlib.rl first. Please read :doc:`installation`.
+install mwlib first. Please read :doc:`installation`.
+
+The Collection extension is optional and can be configured to point
+to your own render server. Please read :doc:`collection`.
 
 Contact/Need help
 ==================

--- a/docs/collection.rst
+++ b/docs/collection.rst
@@ -56,38 +56,30 @@ Installation and Configuration of the Collection Extension
 
     require_once("$IP/extensions/Collection/Collection.php");
 
-If you intend to use the public render server, you're now ready to go.
+Once the extension is installed, you must configure it to point to your
+own render server (see below).
 
 
 Install and Setup a Render Server
----------------------------------
+----------------------------------
 
 Rendering and ZIP file generation is done by a server, which can run
 separately from the MediaWiki installation and can be shared by
 different MediaWikis.
 
-If you have a low-traffic MediaWiki you can use the public render
-server running at http://tools.pediapress.com/mw-serve/. In this case,
-just keep the configuration variable $wgCollectionMWServeURL (see
-below) at its default value.
+The public render server at ``http://tools.pediapress.com/mw-serve/`` is
+**no longer available**. Operators must run their own render server.
 
-Your MediaWiki must be accessible from the render server, i.e. if your
-MediaWiki is behind a firewall you cannot use the public render
-server.
-
-If you can't use the public render server, you'll have to
+You'll have to
 :ref:`install mwlib <mwlib-install>` and
 :ref:`run your own render server <mwlib-renderserver>`.
-See http://mwlib.readthedocs.org/ for more information.
 
-Finally you'll have to set ``$wgCollectionMWServeURL`` in your ``LocalSetting.php``:
+Finally you'll have to set ``$wgCollectionMWServeURL`` in your ``LocalSettings.php``:
 
 ``$wgCollectionMWServeURL`` (string)
 
-  Set this to the URL of a render server (see above).
-
-  The default is ``http://tools.pediapress.com/mw-serve/``, the
-  public render server hosted by PediaPress.
+  Set this to the URL of your render server instance. There is no longer a
+  public default server; this setting must be configured explicitly.
 
 
 Password protected wikis
@@ -133,16 +125,11 @@ people do not have to change them:
 	   'odf' => 'ODT',
        );
 
-   On the public render server tools.pediapress.com, currently the following
-   writers are available:
+   Note: the ``odf`` writer is available but unmaintained. It lacks support for
+   galleries, timelines, hiero, imagemaps, and license handling. The ``rl`` (PDF)
+   writer is the actively maintained option.
 
-   * docbook: DocBook XML
-   * odf: OpenDocument Text
-   * rl: PDF
-   * xhtml: XHTML 1.0 Transitional
-
-   If you're using your own render server, the list of available writers can be
-   listed with the following mwlib_ command::
+   The list of available writers on your render server can be queried with::
 
      $ mw-render --list-writers
 

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -43,7 +43,7 @@ one command.
   * A shortcut for a base URL. Currently there are the following shortcuts:
 
     - ":en" -- http://en.wikipedia.org/w/, i.e. the English Wikipedia
-    - ":de" -- http://en.wikipedia.org/w/, i.e. the German Wikipedia
+    - ":de" -- http://de.wikipedia.org/w/, i.e. the German Wikipedia
 
   * A filename of a ZIP file generated with the `the mw-zip Command`_.
   
@@ -80,8 +80,10 @@ one command.
 ``--login=USERNAME:PASSWORD[:DOMAIN]``
 
   For MediaWikis that restrict the viewing of pages, login with given USERNAME,
-  PASSWORD and optionally DOMAIN.
-  
+  PASSWORD and optionally DOMAIN. This cookie-based login is a legacy method;
+  OAuth2 (configured via the ``[oauth2]`` config section) is the preferred
+  authentication method for production use.
+
   Currently this is only supported for mwapidb, i.e. when the --config argument
   is a base URL or shortcut, or when ``type=mwapi`` in the configuration file.
 
@@ -171,56 +173,82 @@ Specific Options
 ``-p, --posturl=POSTURL``
 
   Upload the ZIP file with an HTTP POST request to the given URL.
+  (This replaces the functionality of the old ``mw-post`` command, which has
+  been removed.)
 
 ``-g , --getposturl``
 
   Retrieve the POSTURL from PediaPress and open the upload page in the web
   browser.
+  (This replaces the functionality of the old ``mw-post`` command, which has
+  been removed.)
 
 
-The ``mw-post`` Command
-=======================
+The ``wme-ingest`` Command
+==========================
 
-Send a ZIP file generated with `the mw-zip command`_ to a given or an
-automatically retrieved URL via HTTP POST request.
+Download a Wikimedia Enterprise namespace 6 snapshot and load the file
+description pages into a BigQuery table. This is used to populate the
+BigQuery-based image lookup cache (see :doc:`configuration` for the
+``[bigquery]`` section).
+
+Requires ``WME_USERNAME`` and ``WME_PASSWORD`` environment variables for
+Wikimedia Enterprise authentication.
 
 Usage
 -----
 ::
 
-  mw-post [OPTIONS]
-  
+  wme-ingest [OPTIONS]
+
 Specific Options
 ----------------
 
-``-i, --input=INPUT``
-  
-  Filename of ZIP file.
+``--list``
 
-``-p, --posturl=POSTURL``
+  List available snapshots and exit. Requires WME credentials.
 
-  Upload the ZIP file with an HTTP POST request to the given URL.
+``--download-only``
 
-``-g , --getposturl``
+  Download the snapshot tarball but skip loading into BigQuery.
 
-  Retrieve the POSTURL from PediaPress and open the upload page in the web
-  browser.
+``--streaming-insert``
 
+  Use BigQuery streaming inserts instead of the default batch load job.
+  Streaming inserts are slower and more expensive for large tables, but
+  make rows immediately queryable.
 
+``--snapshot-id=SNAPSHOT_ID``
 
-The ``mw-serve-ctl`` command
-============================
+  Snapshot identifier to download (default: ``enwiki_namespace_6``).
 
+``-i, --input=TARBALL``
 
-``--purge-cache=HOURS``
+  Path to an already-downloaded ``.tar.gz`` file. Skips the download step
+  and loads from the local file instead.
 
-  Remove all cached files in --cache-dir that haven't been touched for the
-  last HOURS hours. This is meant to be run as a cron job.
+``-o, --output=OUTPUT``
 
-``--clean-up``
+  Output path for the downloaded tarball (default: auto-generated in ``/tmp``).
 
-  Report errors for processes that have died irregularly.
+``--project=PROJECT``
 
+  Google Cloud project ID. Defaults to the ``BIGQUERY_PROJECT`` environment
+  variable, or ``pediapress-prod`` if not set.
+
+``--dataset=DATASET``
+
+  BigQuery dataset ID. Defaults to the ``BIGQUERY_DATASET`` environment
+  variable, or ``wikipedia`` if not set.
+
+``--credentials=PATH``
+
+  Path to a GCP service account JSON key file. Defaults to the
+  ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable.
+
+``--batch-size=N``
+
+  Number of rows per batch for streaming inserts (default: 10000).
 
 
 .. _`MediaWiki API`: http://www.mediawiki.org/wiki/API

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,7 +9,13 @@ mwlib provides several configuration options that can be set in an ini file or t
 Configuration File
 =================
 
-By default, mwlib looks for configuration in ``~/.mwlibrc``. You can also specify a different configuration file path when using the configuration API.
+mwlib looks for configuration files in the following order (later sources override earlier ones):
+
+1. ``~/.mwlibrc`` — user-specific configuration
+2. ``/etc/mwlib.ini`` — system-wide configuration
+3. ``mwlib.ini`` in the current working directory — local configuration
+4. ``.env`` file (loaded via python-dotenv) — environment file
+5. ``MWLIB_*`` environment variables — highest priority
 
 The configuration file uses the ini format with sections and key-value pairs::
 
@@ -19,18 +25,48 @@ The configuration file uses the ini format with sections and key-value pairs::
 Environment Variables
 ====================
 
-Configuration options can also be set through environment variables. The environment variable name is constructed as follows:
+Configuration options can be set through environment variables using the
+pattern ``MWLIB_SECTION_OPTION``. For example, to set ``user_agent`` in the
+``DEFAULT`` section::
 
-- For options in the "mwlib" section: ``MWLIB_OPTION_NAME``
-- For options in other sections: ``MWLIB_SECTION_OPTION_NAME``
+    MWLIB_DEFAULT_USER_AGENT=MyBot/1.0
 
-For example, the "user_agent" option in the "mwlib" section can be set with the ``MWLIB_USER_AGENT`` environment variable.
+Or to set ``max_connections`` in the ``fetch`` section::
+
+    MWLIB_FETCH_MAX_CONNECTIONS=10
+
+The following special environment variables are used directly (without the
+``MWLIB_`` prefix):
+
+``WME_USERNAME``
+  Wikimedia Enterprise API username (used by ``wme-ingest``).
+
+``WME_PASSWORD``
+  Wikimedia Enterprise API password (used by ``wme-ingest``).
+
+``GOOGLE_APPLICATION_CREDENTIALS``
+  Path to a GCP service account JSON key file. Used by BigQuery lookup and
+  ``wme-ingest`` when no ``--credentials`` argument is given.
+
+``BIGQUERY_PROJECT``
+  Default Google Cloud project ID for ``wme-ingest`` (overridden by
+  ``--project``).
+
+``BIGQUERY_DATASET``
+  Default BigQuery dataset ID for ``wme-ingest`` (overridden by
+  ``--dataset``).
+
+``PORT``
+  Port for the nserve render server to listen on.
+
+``XNET``
+  Set to ``1`` to exclude network tests from the test suite.
 
 Available Options
 ================
 
-mwlib Section
-------------
+mwlib Section (DEFAULT)
+-----------------------
 
 user_agent
   The user agent string to use for HTTP requests.
@@ -38,7 +74,14 @@ user_agent
   Default: "mwlib {version}"
 
 oauth2 Section
-------------
+--------------
+
+enabled
+  Whether to use OAuth2 authentication.
+
+  Default: False
+
+  Type: Boolean (yes/true/on/1 for True, no/false/off/0 for False)
 
 client_id
   The OAuth2 client ID for authentication with the MediaWiki API.
@@ -55,15 +98,8 @@ token_url
 
   Default: "https://meta.wikimedia.org/w/rest.php/oauth2/access_token"
 
-enabled
-  Whether to use OAuth2 authentication.
-
-  Default: False
-
-  Type: Boolean (yes/true/on/1 for True, no/false/off/0 for False)
-
 http2 Section
-------------
+-------------
 
 enabled
   Whether to use HTTP/2 for API requests.
@@ -80,7 +116,7 @@ auto_detect
   Type: Boolean (yes/true/on/1 for True, no/false/off/0 for False)
 
 fetch Section
-------------
+-------------
 
 noedits
   Whether edits should be disabled.
@@ -111,11 +147,19 @@ max_connections
   Type: Integer
 
 max_retry_count
-  Maximum number of retry attempts.
+  Maximum number of retry attempts for failed API requests.
 
   Default: 2
 
   Type: Integer
+
+max_requests_per_second
+  Domain-scoped rate limit for API requests (token-bucket limiter). Set to 0
+  to disable rate limiting.
+
+  Default: 0 (disabled)
+
+  Type: Float
 
 rvlimit
   Maximum number of revisions to fetch.
@@ -124,12 +168,63 @@ rvlimit
 
   Type: Integer
 
+bigquery Section
+----------------
+
+The ``[bigquery]`` section enables a BigQuery-backed lookup for File namespace
+description pages. When enabled, mwlib queries a pre-populated BigQuery table
+(sourced from Wikimedia Enterprise snapshots) instead of making remote API
+calls for each image. This can significantly speed up rendering of
+image-heavy articles.
+
+The optional ``google-cloud-bigquery`` dependency must be installed::
+
+    uv pip install "mwlib[bigquery]"
+
+GCP authentication uses ``GOOGLE_APPLICATION_CREDENTIALS`` or Application
+Default Credentials.
+
+enabled
+  Whether to use BigQuery for image description lookups.
+
+  Default: false
+
+  Type: Boolean (yes/true/on/1 for True, no/false/off/0 for False)
+
+project
+  Google Cloud project ID containing the BigQuery dataset.
+
+  Default: "" (required when enabled)
+
+dataset
+  BigQuery dataset ID.
+
+  Default: "wme_snapshots"
+
+table
+  BigQuery table name.
+
+  Default: "file_pages"
+
+timeout
+  Query timeout in seconds.
+
+  Default: 30
+
+  Type: Integer
+
+domains
+  Comma-separated list of wiki domains for which BigQuery lookup is used.
+  Queries for other domains fall back to the normal API.
+
+  Default: "en.wikipedia.org"
+
 Example Configuration
 ====================
 
 Here's an example configuration file::
 
-    [mwlib]
+    [DEFAULT]
     user_agent = MyCustomUserAgent/1.0
 
     [oauth2]
@@ -146,3 +241,13 @@ Here's an example configuration file::
     noedits = yes
     api_result_limit = 1000
     max_connections = 10
+    max_requests_per_second = 5
+    max_retry_count = 3
+
+    [bigquery]
+    enabled = yes
+    project = my-gcp-project
+    dataset = wme_snapshots
+    table = file_pages
+    timeout = 30
+    domains = en.wikipedia.org

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,18 +25,9 @@ and libraries.
 You will also need uv, a fast Python package installer that serves as an
 alternative to pip. See :ref:`installing uv` for installation instructions.
 
-mwlib is split into multiple namespace packages, that each provide
-different functionality:
-
-mwlib
-  core functionality; provides a parser
-
-mwlib.rl
-  generates PDF files from mediawiki articles. This is what is being
-  used on wikipedia in order to generate PDF output.
-
-mwlib.zim
-  generate ZIM files from mediawiki articles
+mwlib is a single package that provides the parser, the PDF writer
+(ReportLab-based), and the ODF writer. There is no longer a separate
+``mwlib.rl`` package — the rl writer is built into mwlib.
 
 
 .. _installing uv:
@@ -82,17 +73,22 @@ Alternatively, if you've cloned the mwlib repository, you can install it using::
 
 This will use uv to install all required dependencies.
 
-Installation of mwlib.rl with uv
-==============================================
-The following command installs the mwlib.rl package::
+Optional: BigQuery support
+=============================================
+To enable BigQuery-backed image description lookup, install the optional
+dependency group::
 
-   $ uv pip install mwlib.rl
+   $ uv pip install "mwlib[bigquery]"
 
-If you want to render right-to-left texts, you must also install the
-pyfribidi package::
+This requires a GCP project and a BigQuery dataset populated with Wikimedia
+Enterprise snapshots (see the ``wme-ingest`` command and :doc:`configuration`).
+
+Optional: right-to-left text
+=============================================
+If you want to render right-to-left texts, you may also install the
+pyfribidi package (Python 3 availability may vary)::
 
    $ uv pip install pyfribidi
-
 
 .. _`test install`:
 
@@ -145,7 +141,7 @@ After that switch to a user account and run::
   export PATH=~/pp/bin:$PATH
   hash -r
   pip install uv
-  uv pip install pyfribidi mwlib mwlib.rl
+  uv pip install mwlib
 
 Install texvc::
 

--- a/docs/writers.rst
+++ b/docs/writers.rst
@@ -76,12 +76,18 @@ attributes::
         }
     }
 
-For example the writer "odf" (defined in ``mwlib.odfwriter``) sets the
+For example the writer "odf" (defined in ``mwlib.writers.odf.writer``) sets the
 attributes to these values::
 
     writer.description = 'OpenDocument Text'
     writer.content_type = 'application/vnd.oasis.opendocument.text'
     writer.file_extension = 'odt'
+
+.. note::
+
+   The ``odf`` writer is unmaintained and incomplete. It lacks support for
+   galleries, timelines, hiero, imagemaps, and license handling. Use the
+   ``rl`` (PDF) writer for production output.
 
 and the writer "rl" from mwlib.rl (defined in `mwlib.writers.rl.writer``) sets
 the attributes to these values::
@@ -108,20 +114,12 @@ Publishing the writer
 Writers are made available as plugins using `setuptools entry points`_.
 They have a name and must belong to the entry point group "mwlib.writers".
 To publish writers in your distribution, add all included writers to the
-entry group by passing the entry_points kwarg to the call to
-``setuptools.setup()`` in your ``setup.py`` file::
+entry group in your ``pyproject.toml`` file::
 
-    setup(
-        ...
-        entry_points = {
-            'mwlib.writers': [
-                'foo = somepackage.foo:writer',
-                'bar = somepackage.barbaz:bar_writer',
-                'baz = somepackage.barbaz:baz_writer',
-            ],
-        },
-        ...
-    )
+    [project.entry-points."mwlib.writers"]
+    foo = "somepackage.foo:writer"
+    bar = "somepackage.barbaz:bar_writer"
+    baz = "somepackage.barbaz:baz_writer"
 
 
 Using writers

--- a/feature_planning/bigquery-image-description-lookup.md
+++ b/feature_planning/bigquery-image-description-lookup.md
@@ -1,0 +1,435 @@
+# Plan: BigQuery-first lookup for image description pages
+
+## Context
+
+mwlib fetches image description pages (NS 6 / `File:` pages) from the remote MediaWiki API during ZIP creation to enable license checking. For English Wikipedia this generates many API requests subject to rate limits. The Wikimedia Enterprise (WME) API provides snapshot data as NDJSON with pre-extracted fields (templates, license, image dimensions). By loading this into BigQuery, we can batch-lookup description page data locally — bypassing Wikipedia rate limits.
+
+**Initial scope**: English Wikipedia namespace 6. Commons is not available from WME. The set of BigQuery-backed domains is fully configurable via environment variable.
+
+**Key insight**: The BigQuery table stores pre-extracted data (templates, license info, image URL/dimensions) — not raw wikitext. This means the lookup replaces both `fetch_image_page` (wikitext fetch) and provides supplemental imageinfo, without needing to parse wikitext at render time.
+
+## BigQuery Table Schema
+
+```json
+[
+  {"name": "name",              "type": "STRING",    "mode": "REQUIRED", "description": "Page title (e.g. File:Example.jpg)"},
+  {"name": "identifier",        "type": "INTEGER",   "description": "MediaWiki page ID"},
+  {"name": "url",               "type": "STRING",    "description": "Full URL to the wiki page"},
+  {"name": "date_modified",     "type": "TIMESTAMP", "description": "Last modification timestamp"},
+  {"name": "license",           "type": "JSON",      "description": "License information array"},
+  {"name": "templates",         "type": "JSON",      "description": "Templates used on the page (for license checking)"},
+  {"name": "categories",        "type": "JSON",      "description": "Categories the page belongs to"},
+  {"name": "abstract",          "type": "STRING",    "description": "Short description / abstract"},
+  {"name": "image_content_url", "type": "STRING",    "description": "URL to the actual image file"},
+  {"name": "image_width",       "type": "INTEGER",   "description": "Image width in pixels"},
+  {"name": "image_height",      "type": "INTEGER",   "description": "Image height in pixels"}
+]
+```
+
+## Implementation
+
+### Step 1: Add `google-cloud-bigquery` as optional dependency
+
+**File**: `pyproject.toml`
+
+```toml
+[dependency-groups]
+bigquery = ["google-cloud-bigquery>=3.0"]
+```
+
+### Step 2: Add BigQuery + WME config defaults
+
+**File**: `src/mwlib/utils/_conf.py` — add to `default_config` dict (line ~72)
+
+```python
+"bigquery": {
+    "enabled": "false",
+    "project": "",
+    "dataset": "wme_snapshots",
+    "table": "file_pages",
+    "timeout": "30",
+    "domains": "en.wikipedia.org",
+},
+```
+
+All keys configurable via environment variables:
+
+| Config key | Env var | Default | Description |
+|---|---|---|---|
+| `bigquery.enabled` | `MWLIB_BIGQUERY_ENABLED` | `false` | Master switch |
+| `bigquery.project` | `MWLIB_BIGQUERY_PROJECT` | _(required when enabled)_ | GCP project ID |
+| `bigquery.dataset` | `MWLIB_BIGQUERY_DATASET` | `wme_snapshots` | BigQuery dataset name |
+| `bigquery.table` | `MWLIB_BIGQUERY_TABLE` | `file_pages` | BigQuery table name |
+| `bigquery.timeout` | `MWLIB_BIGQUERY_TIMEOUT` | `30` | Query timeout in seconds |
+| `bigquery.domains` | `MWLIB_BIGQUERY_DOMAINS` | `en.wikipedia.org` | Comma-separated domains to route through BigQuery |
+
+WME credentials for ingestion: `MWLIB_WME_USERNAME`, `MWLIB_WME_PASSWORD`.
+
+GCP auth via standard `GOOGLE_APPLICATION_CREDENTIALS` env var.
+
+### Templates field and license checking
+
+The `LicenseChecker` (licensechecker.py:131) calls `image_db.get_image_templates_and_args(imgname)` which returns lowercased template names matched against `wplicenses.csv`. The current `get_image_templates_and_args` (nuwiki.py:479-506) returns both:
+1. **Template names** from the page (e.g., `cc-by-4.0`, `pd-old`) — extracted via `get_templates(rawtext)`
+2. **Template argument names** (strings with len > 3, no spaces) — a heuristic to catch license identifiers passed as arguments (e.g. `{{Information|license=cc-by-4.0}}`)
+
+The WME `templates` field contains template names used on the page. This covers (1) directly. For (2), the argument-name heuristic: most license templates on Commons/enwiki are standalone (e.g., `{{cc-by-4.0}}`), not passed as arguments. The WME templates list should be sufficient for the vast majority of license decisions. If edge cases arise, we can refine later.
+
+**License checking at fetch time**: Currently licenses are only checked at render time. By moving the check to fetch time (inside `_store_bq_result` or after BigQuery results arrive), we can skip downloading images that would be filtered out anyway. The `LicenseChecker` needs templates + the license CSV — both available at fetch time. We'll instantiate a `LicenseChecker` in the `Fetcher` and use the BigQuery-provided templates to make the decision before scheduling image downloads.
+
+### imageinfo.db compatibility
+
+The renderer uses `imageinfo.db` only in `set_svg_default_size` (rl/writer.py:1709) to read `url` (check if SVG), `width`, and `height`. The BigQuery schema has `image_content_url`, `image_width`, `image_height` which map to these fields. However, `imageinfo.db` is primarily populated by `_extract_info_from_image` from the `fetch_imageinfo` API call — which **always runs** (it provides `thumburl` for downloads). BigQuery data only supplements via `setdefault()`, so existing API data takes priority. The BigQuery data is sufficient for any fields the API doesn't provide.
+
+### Step 3: Add `templates.db` to FsOutput and NuWiki
+
+The BigQuery data has pre-extracted templates — no wikitext to parse. We need a new storage channel.
+
+**File**: `src/mwlib/network/fetch.py` — `FsOutput.__init__` (line 114)
+
+Add `"templates"` to the storage list:
+```python
+for storage in ["authors", "html", "imageinfo", "templates"]:
+```
+
+This creates a `templates.db` SqliteDict where BigQuery results can write `title → json(template_list)`.
+
+**File**: `src/mwlib/core/nuwiki.py` — `NuWiki.__init__` (after line 116)
+
+Load `templates.db` if it exists:
+```python
+file_name = os.path.join(self.path, "templates.db")
+self.templates = DumbJsonDB(file_name) if os.path.exists(file_name) else None
+```
+
+**File**: `src/mwlib/core/nuwiki.py` — `Adapt.get_image_templates_and_args` (line 479)
+
+Check `templates.db` first before falling back to wikitext parsing:
+```python
+def get_image_templates_and_args(self, name, wikidb=None):
+    # Check pre-extracted templates (from BigQuery) first
+    if self.nuwiki.templates is not None:
+        _, partial, fqname = self.nshandler.splitname(name, nshandling.NS_FILE)
+        for lookup_name in [fqname, self.en_nshandler.get_fqname(partial, nshandling.NS_FILE)]:
+            try:
+                cached = self.nuwiki.templates[lookup_name]
+                if cached:
+                    return set(cached)
+            except KeyError:
+                pass
+
+    # Existing wikitext parsing path (unchanged)
+    from mwlib.parser.expander import get_templates
+    page = self.get_image_description_page(name)
+    ...
+```
+
+### Step 4: Create `src/mwlib/network/bigquery_lookup.py`
+
+New module:
+
+```python
+class BigQueryImageLookup:
+    def __init__(self):
+        # Read project/dataset/table/timeout/domains from conf
+        # Parse domains into a set for O(1) lookup
+        # Lazy-import google.cloud.bigquery
+        # Init Client with REST transport (create_bq_storage_client=False)
+        #   to avoid gRPC/gevent compatibility issues
+
+    @property
+    def is_available(self) -> bool:
+        # True if client initialized successfully
+
+    def handles_domain(self, path: str) -> bool:
+        # Check if any configured domain appears in path
+
+    def fetch_batch(self, titles: list[str]) -> tuple[list[dict], list[str]]:
+        # Parameterized query:
+        #   SELECT name, identifier, url, license, templates, categories,
+        #          abstract, image_content_url, image_width, image_height
+        #   FROM `{project}.{dataset}.{table}`
+        #   WHERE name IN UNNEST(@titles)
+        #
+        # Returns (rows, missing_titles):
+        #   - rows: list of dicts with BigQuery row data
+        #   - missing_titles: titles not found → fall through to remote API
+        #
+        # On ANY exception: log warning, return ([], all_titles) → full fallback
+```
+
+### Step 5: Integrate into `Fetcher` in `fetch.py`
+
+**File**: `src/mwlib/network/fetch.py`
+
+**Batching strategy**: `handle_new_basepath` is called via `_refcall` from `fetch_imageinfo`, and multiple `fetch_imageinfo` calls run concurrently. The same base path can trigger multiple `handle_new_basepath` calls, each with a subset of titles. To minimize BigQuery round-trips, we collect BigQuery-eligible titles into a pending list and flush them in a single query when the batch is large enough or when all tasks are draining.
+
+**5a. Init in `__init__`** (after line ~377):
+```python
+self.bq_lookup = None
+self._bq_pending = []              # (title, api) tuples awaiting BQ lookup
+self._bq_batch_size = 50           # flush threshold
+self._bq_deferred_downloads = {}   # title → thumburl, awaiting license check
+if conf.get("bigquery", "enabled", False, bool):
+    from mwlib.network.bigquery_lookup import BigQueryImageLookup
+    try:
+        self.bq_lookup = BigQueryImageLookup()
+    except Exception:
+        logger.warning("BigQuery lookup init failed, using remote API", exc_info=True)
+```
+
+**5b. Modify `handle_new_basepath`** (lines 965-992):
+
+For BigQuery-eligible domains, collect titles into `_bq_pending` instead of dispatching immediately. For non-eligible domains, existing flow is unchanged.
+
+```python
+def handle_new_basepath(self, path):
+    api = self._get_mwapi_for_path(path)
+    todo = self.imagedescription_todo[path]
+    del self.imagedescription_todo[path]
+
+    titles = {x[0] for x in todo}
+    titles = [t for t in titles if "-d-" + t not in self.scheduled]
+    self.scheduled.update(["-d-" + x for x in titles])
+    if not titles:
+        return
+
+    siteinfo = self.get_siteinfo_for(api)
+    ns_handler = nshandling.NsHandler(siteinfo)
+    nsname = ns_handler.get_nsname_by_number(6)
+
+    local_names = []
+    for title in titles:
+        partial = title.split(":", 1)[1]
+        local_names.append(f"{nsname}:{partial}")
+
+    # BigQuery-eligible: collect into pending batch
+    if self.bq_lookup and self.bq_lookup.is_available and self.bq_lookup.handles_domain(path):
+        for name in local_names:
+            self._bq_pending.append((name, api))
+        if len(self._bq_pending) >= self._bq_batch_size:
+            self._flush_bq_batch()
+        # Contributor lookup always uses remote API
+        for title in local_names:
+            self._refcall(self.get_image_edits, title, api)
+        return
+
+    # Non-BigQuery path: unchanged
+    for block in split_blocks(local_names, api.api_request_limit):
+        self._refcall(self.fetch_image_page, block, api)
+    for title in local_names:
+        self._refcall(self.get_image_edits, title, api)
+```
+
+**5c. Add `_flush_bq_batch` method**:
+
+Called when batch reaches threshold, and also at end of fetching (in `run()` or a cleanup step) to flush remaining titles.
+
+```python
+def _flush_bq_batch(self):
+    """Send all pending titles to BigQuery in a single query, fall back to remote API for misses."""
+    if not self._bq_pending:
+        return
+
+    pending = self._bq_pending
+    self._bq_pending = []
+
+    titles = [t for t, _ in pending]
+    api_by_title = {t: api for t, api in pending}
+
+    rows, missing = self.bq_lookup.fetch_batch(titles)
+
+    # Store BigQuery results + license check + deferred downloads
+    for row in rows:
+        title = row["name"]
+        passes_license = self._store_bq_result(row)
+        if passes_license and title in self._bq_deferred_downloads:
+            self.schedule_download_image(self._bq_deferred_downloads.pop(title), title)
+        elif not passes_license:
+            self._bq_deferred_downloads.pop(title, None)
+            logger.info("Skipping image download for %s (license filtered)", title)
+
+    # Fall back to remote API for missing titles
+    if missing:
+        by_api = {}
+        for title in missing:
+            api = api_by_title[title]
+            by_api.setdefault(api, []).append(title)
+        for api, api_titles in by_api.items():
+            for block in split_blocks(api_titles, api.api_request_limit):
+                self._refcall(self.fetch_image_page, block, api)
+        # Schedule deferred downloads for fallback titles (no license info yet)
+        for title in missing:
+            if title in self._bq_deferred_downloads:
+                self.schedule_download_image(self._bq_deferred_downloads.pop(title), title)
+```
+
+Must also be called in `finish()` (line 1085) to flush remaining titles below batch threshold.
+
+**5d. Initialize `LicenseChecker` for early filtering** (in `__init__`, alongside bq_lookup):
+
+When BigQuery is enabled, create a `LicenseChecker` instance for use at fetch time. This allows skipping image downloads for images that would be filtered at render time anyway.
+
+The filter_type must match the render-time policy. The RL writer (writer.py:173-186) uses:
+- `"whitelist"` for `de.wikipedia.org` (only "free" licenses allowed)
+- `"blacklist"` for everything else (all except "nonfree" allowed)
+
+We derive the filter_type from the primary wiki URL:
+
+```python
+self.fetch_license_checker = None
+if self.bq_lookup:
+    from mwlib.rendering.licensechecker import LicenseChecker
+    # Match the render-time policy: de.wikipedia.org uses whitelist, others use blacklist
+    filter_type = "whitelist" if "de.wikipedia.org" in self.api.apiurl else "blacklist"
+    self.fetch_license_checker = LicenseChecker(image_db=None, filter_type=filter_type)
+    self.fetch_license_checker.read_licenses_csv()
+```
+
+The `image_db=None` is fine — `_check_license_from_templates` uses `_get_licenses` directly without needing image_db.
+
+**5e. Add `_check_license_from_templates` helper**:
+
+```python
+def _check_license_from_templates(self, title: str, templates: list[str]) -> bool:
+    """Check if image should be included based on templates. Returns True if image passes filter."""
+    if not self.fetch_license_checker:
+        return True  # no checker → include everything
+    lowered = [t.lower() for t in templates]
+    licenses = self.fetch_license_checker._get_licenses(lowered)
+    # Simplified check: no stats tracking (no image_db needed)
+    for lic in licenses:
+        if lic.license_type == "free":
+            return True
+        elif lic.license_type == "nonfree":
+            return self.fetch_license_checker.filter_type == "nofilter"
+    # All unknown → follow filter_type
+    return self.fetch_license_checker.filter_type in ["blacklist", "nofilter"]
+```
+
+**5f. Use early license check in `_store_bq_result`** to skip image download scheduling:
+
+The `_store_bq_result` method returns a boolean indicating whether the image passed the license check. The caller (`_flush_bq_batch`) uses this to decide whether to skip the image download (but still stores templates for render-time use).
+
+**5g. Add `_store_bq_result` helper**:
+
+```python
+def _store_bq_result(self, row) -> bool:
+    """Store a BigQuery row into fsout databases. Returns True if image passes license check."""
+    title = row["name"]
+
+    # Store pre-extracted templates in templates.db
+    templates = row.get("templates", [])
+    if templates:
+        self.fsout.set_db_key("templates", title, templates)
+
+    # Early license check — skip image download if it won't pass filter
+    passes_license = self._check_license_from_templates(title, templates)
+
+    # Supplement imageinfo with dimensions and content URL
+    existing = {}
+    try:
+        existing = self.fsout.get_db_key("imageinfo", title)
+    except (KeyError, Exception):
+        pass
+
+    if row.get("image_content_url"):
+        existing.setdefault("url", row["image_content_url"])
+    if row.get("image_width"):
+        existing.setdefault("width", row["image_width"])
+    if row.get("image_height"):
+        existing.setdefault("height", row["image_height"])
+    if row.get("url"):
+        existing.setdefault("descriptionurl", row["url"])
+
+    if existing:
+        self.fsout.set_db_key("imageinfo", title, existing)
+
+    return passes_license
+```
+
+**5h. Defer image downloads for BigQuery-eligible domains**:
+
+Currently, `_extract_info_from_image` (line 910-933) calls `schedule_download_image` immediately. For BigQuery-eligible domains, we defer the download until after the license check.
+
+Modify `_extract_info_from_image` to check if the description URL path is BigQuery-eligible. If yes, store `(thumburl, title)` in a new `_bq_deferred_downloads` dict (keyed by title) instead of calling `schedule_download_image`. The download info travels alongside the title through `_bq_pending` → `_flush_bq_batch`.
+
+In `_flush_bq_batch`, after BigQuery results arrive and `_store_bq_result` returns the license decision:
+- If license passes: call `schedule_download_image(url, title)` for the deferred download
+- If license fails: skip the download entirely, log the filtered image
+
+For titles that fall back to the remote API (missing from BigQuery): schedule their downloads immediately in the fallback path since we don't have templates to check.
+
+```python
+def _extract_info_from_image(self, image, imageinfo, new_base_paths, title):
+    self.fsout.set_db_key("imageinfo", title, imageinfo)
+    thumb_url = imageinfo.get("thumburl") or imageinfo.get("url")
+    if thumb_url:
+        if thumb_url.startswith("/"):
+            thumb_url = parse.urljoin(self.api.baseurl, thumb_url)
+
+        description_url = imageinfo.get("descriptionurl", "") or image.get("fullurl", "")
+
+        # Check if this image is BigQuery-eligible (defer download)
+        if self.bq_lookup and description_url and self.bq_lookup.handles_domain(description_url):
+            self._bq_deferred_downloads[title] = thumb_url
+        else:
+            self.schedule_download_image(thumb_url, title)
+
+        if description_url and "/" in description_url:
+            path, _ = description_url.rsplit("/", 1)
+            # ... rest unchanged (imagedescription_todo handling)
+```
+
+### Step 6: Ingestion pipeline (external)
+
+WME snapshot fetching already exists at `../pediapress/infrastructure/bin/fetch_wikimedia_snapshot.py`. No new ingestion code needed in mwlib. The external script downloads NDJSON from the WME API and loads it into BigQuery with the schema defined above.
+
+### Step 7: Tests
+
+**`tests/mwlib/network/test_bigquery_lookup.py`**:
+- Mock `google.cloud.bigquery.Client`
+- `fetch_batch`: all found, partial match, none found, BigQuery error → graceful fallback
+- `handles_domain`: matches configured domains, rejects others
+- Data returned has correct shape
+
+**Extend `tests/mwlib/network/test_fetch.py`**:
+- `handle_new_basepath` with mocked `bq_lookup`: verify BigQuery tried for configured domains, skipped for others
+- `_store_bq_result` writes templates.db and imageinfo.db correctly
+- Fallback when BigQuery returns partial results
+- `get_image_edits` still called for ALL titles
+- Early license check: image with `cc-by-4.0` template → download scheduled; image with `nonfree` template → download skipped
+- `_extract_info_from_image` defers downloads for BQ-eligible domains, schedules immediately for others
+
+**`tests/mwlib/core/test_nuwiki.py`** (extend or create):
+- `get_image_templates_and_args` returns templates from `templates.db` when available
+- Falls back to wikitext parsing when `templates.db` has no entry
+
+
+## Files to create
+- `src/mwlib/network/bigquery_lookup.py`
+- `tests/mwlib/network/test_bigquery_lookup.py`
+
+## Files to modify
+- `pyproject.toml` — dependency group
+- `src/mwlib/utils/_conf.py` — default config for `[bigquery]` section
+- `src/mwlib/network/fetch.py` — `FsOutput.__init__` (add templates.db), `Fetcher.__init__`, `_extract_info_from_image` (defer downloads), `handle_new_basepath`, `_flush_bq_batch`, `_store_bq_result`, `_check_license_from_templates`, `finish()`
+- `src/mwlib/core/nuwiki.py` — `NuWiki.__init__` (load templates.db), `Adapt.get_image_templates_and_args` (check templates.db first)
+
+## Git branch
+
+Create a new branch `feature/bigquery-image-lookup` from `main` before making any changes.
+
+## Execution order
+
+1. Steps 1–2: Dependencies and config
+2. Steps 3–5: Core lookup + storage + fetch integration (templates.db, bigquery_lookup.py, fetch.py changes, nuwiki.py changes)
+3. Step 7: Tests throughout
+
+## Verification
+
+1. **Unit tests**: `py.test tests/mwlib/network/test_bigquery_lookup.py tests/mwlib/core/test_nuwiki.py -v`
+2. **Existing tests pass**: `py.test tests -n6` (BigQuery disabled by default → zero change to existing behavior)
+3. **Manual integration**: With `MWLIB_BIGQUERY_ENABLED=true` + loaded data, run `mw-zip` for an English Wikipedia article with images — verify templates fetched from BigQuery (visible in logs), license checking works
+4. **Fallback**: `MWLIB_BIGQUERY_ENABLED=false` → behavior identical to current
+5. **Domain config**: `MWLIB_BIGQUERY_DOMAINS=de.wikipedia.org,en.wikipedia.org` → both routed through BigQuery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,15 +54,21 @@ classifiers = [
 ]
 license = "BSD-3-Clause"
 
+# Optional runtime extras users opt into with ``pip install mwlib[bigquery]``.
+# ``google-cloud-bigquery`` pulls in gRPC + a pile of Google libs; keeping it
+# out of the default install means consumers who don't run the WME-ingest
+# pipeline or BigQuery image lookup don't pay for those.
+[project.optional-dependencies]
+bigquery = [
+    "google-cloud-bigquery>=3.0",
+]
+
 [dependency-groups]
 dev = [
     "pytest",
     "pytest-httpx>=0.35.0",
     "pytest-xdist",
     "wsgi-intercept",
-]
-bigquery = [
-    "google-cloud-bigquery>=3.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "Cython", "toml"]
 
 [project]
 name = "mwlib"
-version = "0.18.1"
+version = "0.18.2"
 description = "mediawiki parser and utility library"
 authors = [
     {name = "pediapress.com", email = "info@pediapress.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pyparsing",
     "python-dotenv>=1.1.1",
     "reportlab",
+    "requests",
     "roman",
     "simplejson",
     "sqlitedict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ dev = [
     "pytest-xdist",
     "wsgi-intercept",
 ]
+bigquery = [
+    "google-cloud-bigquery>=3.0",
+]
 
 [project.urls]
 homepage = "https://code.pediapress.com/"
@@ -75,6 +78,7 @@ mw-render = "mwlib.core.main_trampoline:mw_render_main"
 mw-version = "mwlib.utils._version:main"
 mw-zip = "mwlib.core.main_trampoline:mw_zip_main"
 postman = "mwlib.core.main_trampoline:postman_main"
+wme-ingest = "mwlib.apps.fetch_wikimedia_snapshot:main"
 
 [tool.ruff]
 force-exclude = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel", "Cython", "toml"]
 
 [project]
 name = "mwlib"
-version = "0.18.2"
+version = "0.18.3"
 description = "mediawiki parser and utility library"
 authors = [
     {name = "pediapress.com", email = "info@pediapress.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,17 @@ bigquery = [
 ]
 
 [dependency-groups]
+# Tests import ``google.cloud.bigquery`` (the BigQuery image lookup and the
+# WME ingest CLI both have unit tests that mock against the SDK), so a clean
+# ``uv sync`` for development needs the extra installed alongside the test
+# runner. Listed here in addition to ``[project.optional-dependencies]`` so
+# end-user installs stay slim while ``uv run pytest`` works without flags.
 dev = [
     "pytest",
     "pytest-httpx>=0.35.0",
     "pytest-xdist",
     "wsgi-intercept",
+    "google-cloud-bigquery>=3.0",
 ]
 
 [project.urls]

--- a/src/mwlib/apps/fetch_wikimedia_snapshot.py
+++ b/src/mwlib/apps/fetch_wikimedia_snapshot.py
@@ -411,36 +411,46 @@ def iter_extract_ndjson(tarball_path: Path) -> Iterator[Path]:
     Members are validated as regular files at relative paths and then
     streamed via ``shutil.copyfileobj`` rather than handed to
     ``tar.extract`` — see ``_validate_tar_member``.
+
+    Extraction lands in a private temporary directory rather than the
+    tarball's parent. Otherwise a member named ``existing.ndjson`` would
+    overwrite ``/path/to/existing.ndjson`` whenever the operator passes
+    ``-i /path/to/snapshot.tar.gz``, and our cleanup would then unlink
+    a file we didn't create.
     """
-    extract_dir = tarball_path.parent
+    with tempfile.TemporaryDirectory(prefix="wme-ndjson-", dir=tarball_path.parent) as tmp:
+        extract_dir = Path(tmp)
 
-    with tarfile.open(tarball_path, "r:gz") as tar:
-        members = [m for m in tar.getmembers() if m.name.endswith(".ndjson")]
-        if not members:
-            raise ValueError(f"No .ndjson files found in {tarball_path}")
-        for m in members:
-            _validate_tar_member(m)
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            members = [m for m in tar.getmembers() if m.name.endswith(".ndjson")]
+            if not members:
+                raise ValueError(f"No .ndjson files found in {tarball_path}")
+            for m in members:
+                _validate_tar_member(m)
 
-        logger.info("Tarball contains %d NDJSON files; will extract one at a time", len(members))
+            logger.info(
+                "Tarball contains %d NDJSON files; will extract one at a time",
+                len(members),
+            )
 
-        for idx, member in enumerate(members, 1):
-            src = tar.extractfile(member)
-            if src is None:
-                raise ValueError(f"Cannot extract tar member: {member.name}")
-            path = extract_dir / member.name
-            path.parent.mkdir(parents=True, exist_ok=True)
-            with src, open(path, "wb") as dst:
-                shutil.copyfileobj(src, dst)
-            logger.info("Extracted %d/%d: %s (%d bytes)", idx, len(members), path, member.size)
-            try:
-                yield path
-            finally:
-                if path.exists():
-                    try:
-                        path.unlink()
-                        logger.info("Removed extracted NDJSON: %s", path)
-                    except OSError:
-                        logger.exception("Failed to clean up %s", path)
+            for idx, member in enumerate(members, 1):
+                src = tar.extractfile(member)
+                if src is None:
+                    raise ValueError(f"Cannot extract tar member: {member.name}")
+                path = extract_dir / member.name
+                path.parent.mkdir(parents=True, exist_ok=True)
+                with src, open(path, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+                logger.info("Extracted %d/%d: %s (%d bytes)", idx, len(members), path, member.size)
+                try:
+                    yield path
+                finally:
+                    if path.exists():
+                        try:
+                            path.unlink()
+                            logger.info("Removed extracted NDJSON: %s", path)
+                        except OSError:
+                            logger.exception("Failed to clean up %s", path)
 
 
 def _make_bq_client(project: str, credentials_path: str | None):
@@ -472,24 +482,36 @@ def _make_bq_schema(schema: list[dict]):
 def _prepare_table(client, table_ref: str, ns: NamespaceConfig) -> None:
     """Ensure the destination table exists with the right schema.
 
-    For script-managed namespaces (NS6) the table is recreated on every run —
-    that's the long-standing behaviour and keeps schema changes effortless.
-    For externally-managed tables (NS0 → Pulumi) the script never drops the
-    table; it just verifies it exists. ``exists_ok=True`` makes the call a
-    no-op when Pulumi has already created it, which is the production case,
-    while still letting the script bootstrap a missing table in dev.
+    For script-managed namespaces (NS6) the table is recreated on every
+    run — that's the long-standing behaviour and keeps schema changes
+    effortless.
+
+    For externally-managed tables (NS0 → Pulumi) the script must NOT
+    bootstrap the table. Pulumi is the source of truth for the
+    clustering / deletion-protection / partitioning settings; if we
+    silently created the table when missing we'd produce a stripped-down
+    table without those guarantees and the next Pulumi run would see
+    drift. Fail loudly with a pointer to the operator instead.
     """
     from google.cloud import bigquery
 
-    schema = _make_bq_schema(ns.schema)
-    table = bigquery.Table(table_ref, schema=schema)
-
     if ns.script_manages_table:
+        schema = _make_bq_schema(ns.schema)
+        table = bigquery.Table(table_ref, schema=schema)
         client.delete_table(table_ref, not_found_ok=True)
         client.create_table(table)
         logger.info("Created BigQuery table %s", table_ref)
     else:
-        client.create_table(table, exists_ok=True)
+        try:
+            client.get_table(table_ref)
+        except Exception as exc:
+            raise RuntimeError(
+                f"BigQuery table {table_ref} is externally managed (e.g. by "
+                f"Pulumi) and could not be found. Provision it before running "
+                f"the ingest — the script refuses to bootstrap a missing "
+                f"externally-managed table because doing so would silently "
+                f"drop clustering / deletion-protection settings."
+            ) from exc
         logger.info("Using BigQuery table %s (managed externally)", table_ref)
 
 
@@ -693,8 +715,19 @@ def load_tarball_to_bigquery(
     """
     from google.cloud import bigquery
 
+    from mwlib.network.bigquery_lookup import _validate_bigquery_identifier
+
     client = _make_bq_client(project, credentials_path)
-    table_ref = f"{project}.{dataset}.{ns.table_id}"
+    # ``project`` and ``dataset`` come from CLI flags / env vars and end
+    # up interpolated into the raw ``TRUNCATE TABLE`` statement below.
+    # BigQuery identifiers can't be passed as query parameters, so
+    # validate them here exactly like ``BigQueryImageLookup._execute_query``
+    # does at runtime — a backtick in either value would otherwise close
+    # ``table_ref`` early.
+    safe_project = _validate_bigquery_identifier(project, "project")
+    safe_dataset = _validate_bigquery_identifier(dataset, "dataset")
+    safe_table = _validate_bigquery_identifier(ns.table_id, "table")
+    table_ref = f"{safe_project}.{safe_dataset}.{safe_table}"
     _prepare_table(client, table_ref, ns)
 
     schema = None

--- a/src/mwlib/apps/fetch_wikimedia_snapshot.py
+++ b/src/mwlib/apps/fetch_wikimedia_snapshot.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Fetch Wikimedia Enterprise namespace 6 snapshot and load into BigQuery.
+
+Authentication:
+    Uses WME_USERNAME / WME_PASSWORD env vars to obtain a bearer token from
+    the Wikimedia Enterprise auth endpoint.
+
+BigQuery:
+    Uses GOOGLE_APPLICATION_CREDENTIALS (or the service account JSON path
+    passed via --credentials) for authentication.
+
+Data handling:
+    Each run replaces all data in the target table (WRITE_TRUNCATE / drop+create).
+    This is intentional for snapshot ETL — no upsert logic is needed.
+
+Usage examples:
+    # List available snapshots
+    python fetch_wikimedia_snapshot.py --list
+
+    # Download namespace 6 snapshot only (no BigQuery load)
+    python fetch_wikimedia_snapshot.py --download-only -o enwiki_ns6.tar.gz
+
+    # Full pipeline: download + load into BigQuery (default: batch load job)
+    python fetch_wikimedia_snapshot.py --project pediapress-prod --dataset wikipedia
+
+    # Load from an already-downloaded tarball (skip download)
+    python fetch_wikimedia_snapshot.py -i /path/to/enwiki_ns6.tar.gz
+
+    # Use streaming inserts instead of batch load job
+    python fetch_wikimedia_snapshot.py --streaming-insert --project pediapress-prod
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+import requests
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+WME_AUTH_URL = "https://auth.enterprise.wikimedia.com/v1/login"
+WME_API_BASE = "https://api.enterprise.wikimedia.com/v2"
+DEFAULT_SNAPSHOT_ID = "enwiki_namespace_6"
+
+# BigQuery schema for the namespace 6 file description pages.
+# Focused on fields needed for license checking. article_body_html is omitted
+# to avoid storage bloat — templates and categories cover license-checking needs.
+BQ_TABLE_ID = "file_pages"
+BQ_SCHEMA = [
+    {
+        "name": "name",
+        "type": "STRING",
+        "mode": "REQUIRED",
+        "description": "Page title (e.g. File:Example.jpg)",
+    },
+    {
+        "name": "identifier",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "MediaWiki page ID",
+    },
+    {
+        "name": "url",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "Full URL to the wiki page",
+    },
+    {
+        "name": "date_modified",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE",
+        "description": "Last modification timestamp",
+    },
+    {
+        "name": "license",
+        "type": "JSON",
+        "mode": "NULLABLE",
+        "description": "License information array",
+    },
+    {
+        "name": "templates",
+        "type": "JSON",
+        "mode": "NULLABLE",
+        "description": "Templates used on the page (for license checking)",
+    },
+    {
+        "name": "categories",
+        "type": "JSON",
+        "mode": "NULLABLE",
+        "description": "Categories the page belongs to",
+    },
+    {
+        "name": "abstract",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "Short description / abstract",
+    },
+    {
+        "name": "image_content_url",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "URL to the actual image file",
+    },
+    {
+        "name": "image_width",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "Image width in pixels",
+    },
+    {
+        "name": "image_height",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "Image height in pixels",
+    },
+]
+
+# Progress logging interval (bytes) during download
+_DOWNLOAD_LOG_INTERVAL = 100 * 1024 * 1024  # log every 100 MB
+
+
+def get_bearer_token(username: str, password: str) -> str:
+    """Authenticate with Wikimedia Enterprise and return an access token."""
+    logger.info("Authenticating with Wikimedia Enterprise API...")
+    resp = requests.post(
+        WME_AUTH_URL,
+        json={"username": username, "password": password},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    token = data["access_token"]
+    logger.info(
+        "Authentication successful (token expires in %ss)", data.get("expires_in")
+    )
+    return token
+
+
+def list_snapshots(token: str) -> list[dict]:
+    """List available snapshots from the Wikimedia Enterprise API."""
+    resp = requests.get(
+        f"{WME_API_BASE}/snapshots",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def download_snapshot_streaming(
+    token: str,
+    snapshot_id: str,
+    output_path: Path,
+) -> Path:
+    """Download a snapshot as a gzipped tarball, streaming to disk.
+
+    Verifies download completeness by comparing bytes received to Content-Length.
+    """
+    url = f"{WME_API_BASE}/snapshots/{snapshot_id}/download"
+    logger.info(
+        "Downloading snapshot %s to %s (streaming)...", snapshot_id, output_path
+    )
+
+    resp = requests.get(
+        url,
+        headers={"Authorization": f"Bearer {token}"},
+        stream=True,
+        timeout=(30, None),  # 30s connect, no read timeout for large downloads
+    )
+    resp.raise_for_status()
+
+    total = int(resp.headers.get("content-length", 0))
+    downloaded = 0
+    last_logged = 0
+    sha256 = hashlib.sha256()
+
+    with open(output_path, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=8 * 1024 * 1024):  # 8MB chunks
+            f.write(chunk)
+            sha256.update(chunk)
+            downloaded += len(chunk)
+            if downloaded - last_logged >= _DOWNLOAD_LOG_INTERVAL:
+                if total > 0:
+                    pct = 100.0 * downloaded / total
+                    logger.info(
+                        "  %.1f%% (%d / %d MB)", pct, downloaded >> 20, total >> 20
+                    )
+                else:
+                    logger.info("  %d MB downloaded", downloaded >> 20)
+                last_logged = downloaded
+
+    # Verify completeness
+    if total > 0 and downloaded != total:
+        os.unlink(output_path)
+        raise RuntimeError(
+            f"Download incomplete: expected {total} bytes, got {downloaded}. "
+            f"File removed. Please retry."
+        )
+
+    logger.info(
+        "Download complete: %s (%d MB, sha256=%s)",
+        output_path,
+        downloaded >> 20,
+        sha256.hexdigest()[:16],
+    )
+    return output_path
+
+
+def extract_ndjson_from_tarball(tarball_path: Path) -> list[Path]:
+    """Extract all .ndjson files from a gzipped tarball.
+
+    Returns a list of paths to the extracted NDJSON files.
+    """
+    logger.info("Extracting NDJSON files from %s...", tarball_path)
+    extract_dir = tarball_path.parent
+
+    with tarfile.open(tarball_path, "r:gz") as tar:
+        ndjson_members = [m for m in tar.getmembers() if m.name.endswith(".ndjson")]
+        if not ndjson_members:
+            raise ValueError(f"No .ndjson files found in {tarball_path}")
+
+        # Path traversal guard
+        for m in ndjson_members:
+            if Path(m.name).is_absolute() or ".." in Path(m.name).parts:
+                raise ValueError(f"Suspicious tar member path: {m.name}")
+
+        extracted = []
+        for member in ndjson_members:
+            tar.extract(member, path=extract_dir)
+            path = extract_dir / member.name
+            logger.info("Extracted: %s (%d bytes)", path, member.size)
+            extracted.append(path)
+
+        logger.info("Extracted %d NDJSON files", len(extracted))
+        return extracted
+
+
+def parse_ndjson_row(line: str) -> dict | None:
+    """Parse a single NDJSON line into a BigQuery-compatible row."""
+    try:
+        doc = json.loads(line)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed JSON line: %s...", line[:100])
+        return None
+
+    name = doc.get("name")
+    if not name:
+        logger.warning("Skipping row with missing 'name' field: %s...", line[:100])
+        return None
+
+    row = {
+        "name": name,
+        "identifier": doc.get("identifier"),
+        "url": doc.get("url"),
+        "date_modified": doc.get("date_modified"),
+    }
+
+    # Serialize complex fields as JSON strings for BigQuery JSON columns
+    if "license" in doc and doc["license"]:
+        row["license"] = json.dumps(doc["license"])
+    if "templates" in doc and doc["templates"]:
+        row["templates"] = json.dumps(doc["templates"])
+    if "categories" in doc and doc["categories"]:
+        row["categories"] = json.dumps(doc["categories"])
+
+    row["abstract"] = doc.get("abstract")
+
+    # Extract image metadata
+    image = doc.get("image")
+    if image and isinstance(image, dict):
+        row["image_content_url"] = image.get("content_url")
+        row["image_width"] = image.get("width")
+        row["image_height"] = image.get("height")
+
+    return row
+
+
+def _make_bq_client(project: str, credentials_path: str | None):
+    """Create a BigQuery client with optional service account credentials."""
+    from google.cloud import bigquery
+    from google.oauth2 import service_account
+
+    if credentials_path:
+        creds = service_account.Credentials.from_service_account_file(credentials_path)
+        return bigquery.Client(project=project, credentials=creds)
+    return bigquery.Client(project=project)
+
+
+def _make_bq_schema():
+    """Build a list of BigQuery SchemaField objects from BQ_SCHEMA."""
+    from google.cloud import bigquery
+
+    return [
+        bigquery.SchemaField(
+            name=f["name"],
+            field_type=f["type"],
+            mode=f["mode"],
+            description=f.get("description", ""),
+        )
+        for f in BQ_SCHEMA
+    ]
+
+
+def load_ndjson_to_bigquery_streaming(
+    ndjson_paths: list[Path],
+    project: str,
+    dataset: str,
+    credentials_path: str | None = None,
+    batch_size: int = 10_000,
+) -> int:
+    """Load parsed NDJSON rows into BigQuery using the streaming insert API.
+
+    Processes all NDJSON files in order. Failed rows are retried once.
+
+    Returns the total number of rows successfully loaded.
+    """
+    client = _make_bq_client(project, credentials_path)
+    table_ref = f"{project}.{dataset}.{BQ_TABLE_ID}"
+
+    schema = _make_bq_schema()
+    from google.cloud import bigquery
+
+    table = bigquery.Table(table_ref, schema=schema)
+    client.delete_table(table_ref, not_found_ok=True)
+    client.create_table(table)
+    logger.info("Created BigQuery table %s", table_ref)
+
+    total_rows = 0
+    skipped_rows = 0
+    errors_total = 0
+
+    for file_idx, ndjson_path in enumerate(ndjson_paths, 1):
+        logger.info(
+            "Processing file %d/%d: %s", file_idx, len(ndjson_paths), ndjson_path
+        )
+        batch = []
+
+        with open(ndjson_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+
+                row = parse_ndjson_row(line)
+                if row is None:
+                    skipped_rows += 1
+                    continue
+
+                batch.append(row)
+
+                if len(batch) >= batch_size:
+                    inserted, failed = _insert_batch_with_retry(
+                        client, table_ref, batch
+                    )
+                    total_rows += inserted
+                    errors_total += failed
+                    logger.info(
+                        "Loaded %d rows (%d total, %d errors so far)...",
+                        inserted,
+                        total_rows,
+                        errors_total,
+                    )
+                    batch = []
+
+        # Final batch for this file
+        if batch:
+            inserted, failed = _insert_batch_with_retry(client, table_ref, batch)
+            total_rows += inserted
+            errors_total += failed
+
+    logger.info(
+        "Load complete: %d rows loaded from %d files, %d errors, %d skipped",
+        total_rows,
+        len(ndjson_paths),
+        errors_total,
+        skipped_rows,
+    )
+    if errors_total > 0:
+        logger.error(
+            "WARNING: %d rows failed to insert. The table may be incomplete.",
+            errors_total,
+        )
+    return total_rows
+
+
+def _insert_batch_with_retry(
+    client, table_ref: str, batch: list[dict]
+) -> tuple[int, int]:
+    """Insert a batch of rows, retrying failed rows once.
+
+    Returns (inserted_count, failed_count).
+    """
+    errors = client.insert_rows_json(table_ref, batch)
+    if not errors:
+        return len(batch), 0
+
+    # Identify which rows failed
+    failed_indices = set()
+    for err in errors:
+        idx = err.get("index")
+        if idx is not None:
+            failed_indices.add(idx)
+        for detail in err.get("errors", []):
+            logger.warning("  Insert error: %s", detail)
+
+    if not failed_indices:
+        # Can't determine which rows failed — count all as failed
+        logger.warning("Insert returned %d errors but no row indices", len(errors))
+        return 0, len(batch)
+
+    succeeded = len(batch) - len(failed_indices)
+
+    # Retry failed rows once
+    retry_batch = [batch[i] for i in sorted(failed_indices)]
+    logger.info("Retrying %d failed rows...", len(retry_batch))
+    retry_errors = client.insert_rows_json(table_ref, retry_batch)
+    if not retry_errors:
+        return len(batch), 0
+
+    # Log permanently failed rows
+    permanent_failures = len(retry_errors)
+    for err in retry_errors[:3]:
+        logger.error("Permanent insert failure: %s", err)
+
+    return succeeded + (len(retry_batch) - permanent_failures), permanent_failures
+
+
+def load_ndjson_to_bigquery_load_job(
+    ndjson_paths: list[Path],
+    project: str,
+    dataset: str,
+    credentials_path: str | None = None,
+) -> int:
+    """Load NDJSON into BigQuery using a load job (better for large files).
+
+    Reads all NDJSON files, converts each line to our schema, writes to a
+    single temporary file, then uses a BigQuery load job with WRITE_TRUNCATE.
+
+    Returns the total number of rows loaded.
+    """
+    from google.cloud import bigquery
+
+    client = _make_bq_client(project, credentials_path)
+    table_ref = f"{project}.{dataset}.{BQ_TABLE_ID}"
+    schema = _make_bq_schema()
+
+    # Write transformed rows from ALL files to a single temp NDJSON file
+    tmp_path = None
+    skipped_rows = 0
+    try:
+        total_rows = 0
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ndjson", delete=False
+        ) as tmp:
+            tmp_path = tmp.name
+            for file_idx, ndjson_path in enumerate(ndjson_paths, 1):
+                logger.info(
+                    "Preparing file %d/%d: %s",
+                    file_idx,
+                    len(ndjson_paths),
+                    ndjson_path,
+                )
+                with open(ndjson_path, encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        row = parse_ndjson_row(line)
+                        if row is None:
+                            skipped_rows += 1
+                            continue
+                        tmp.write(json.dumps(row) + "\n")
+                        total_rows += 1
+
+        logger.info(
+            "Prepared %d rows from %d files for BigQuery load job (%d skipped)",
+            total_rows,
+            len(ndjson_paths),
+            skipped_rows,
+        )
+
+        # Configure load job
+        job_config = bigquery.LoadJobConfig(
+            schema=schema,
+            source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            max_bad_records=0,  # Fail on any bad record
+        )
+
+        with open(tmp_path, "rb") as source:
+            load_job = client.load_table_from_file(
+                source,
+                table_ref,
+                job_config=job_config,
+            )
+
+        logger.info("BigQuery load job started: %s", load_job.job_id)
+        load_job.result()  # Wait for completion
+
+        # Check for errors in the load job
+        if load_job.errors:
+            logger.error("BigQuery load job completed with errors:")
+            for err in load_job.errors:
+                logger.error("  %s", err)
+
+        loaded = load_job.output_rows
+        logger.info("BigQuery load job completed: %d rows loaded", loaded)
+
+        if loaded != total_rows:
+            logger.warning(
+                "Row count mismatch: prepared %d rows but BigQuery loaded %d. "
+                "%d rows may have been rejected.",
+                total_rows,
+                loaded,
+                total_rows - loaded,
+            )
+
+        return loaded
+
+    finally:
+        if tmp_path and Path(tmp_path).exists():
+            os.unlink(tmp_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch Wikimedia Enterprise namespace 6 snapshot and load into BigQuery.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available snapshots and exit",
+    )
+    parser.add_argument(
+        "--download-only",
+        action="store_true",
+        help="Download the snapshot but skip BigQuery loading",
+    )
+    parser.add_argument(
+        "--streaming-insert",
+        action="store_true",
+        help="Use BigQuery streaming inserts instead of the default batch load job",
+    )
+    parser.add_argument(
+        "--snapshot-id",
+        default=DEFAULT_SNAPSHOT_ID,
+        help=f"Snapshot identifier (default: {DEFAULT_SNAPSHOT_ID})",
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        help="Path to an already-downloaded .tar.gz file (skips download)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output path for the downloaded tarball (default: auto-generated in /tmp)",
+    )
+    parser.add_argument(
+        "--project",
+        default=os.environ.get("BIGQUERY_PROJECT", "pediapress-prod"),
+        help="Google Cloud project ID (default: BIGQUERY_PROJECT env or 'pediapress-prod')",
+    )
+    parser.add_argument(
+        "--dataset",
+        default=os.environ.get("BIGQUERY_DATASET", "wikipedia"),
+        help="BigQuery dataset ID (default: BIGQUERY_DATASET env or 'wikipedia')",
+    )
+    parser.add_argument(
+        "--credentials",
+        default=os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
+        help="Path to GCP service account JSON (default: GOOGLE_APPLICATION_CREDENTIALS env)",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=10_000,
+        help="Rows per batch for streaming inserts (default: 10000)",
+    )
+
+    args = parser.parse_args()
+
+    # Load .env if present
+    try:
+        from dotenv import load_dotenv
+
+        env_path = Path(__file__).resolve().parent.parent.parent / ".env"
+        if env_path.exists():
+            load_dotenv(env_path)
+            logger.info("Loaded environment from %s", env_path)
+    except ImportError:
+        pass
+
+    # Use existing tarball or download a new one
+    if args.input:
+        output_path = Path(args.input)
+        if not output_path.exists():
+            logger.error("Input file not found: %s", output_path)
+            sys.exit(1)
+        logger.info("Using existing tarball: %s", output_path)
+    else:
+        # Authenticate with Wikimedia Enterprise
+        username = os.environ.get("WME_USERNAME")
+        password = os.environ.get("WME_PASSWORD")
+        if not username or not password:
+            logger.error(
+                "WME_USERNAME and WME_PASSWORD environment variables are required"
+            )
+            sys.exit(1)
+
+        token = get_bearer_token(username, password)
+
+        # --list mode
+        if args.list:
+            snapshots = list_snapshots(token)
+            print(json.dumps(snapshots, indent=2))
+            return
+
+        # Download snapshot
+        if args.output:
+            output_path = Path(args.output)
+        else:
+            output_path = Path(tempfile.mkdtemp()) / f"{args.snapshot_id}.tar.gz"
+
+        download_snapshot_streaming(token, args.snapshot_id, output_path)
+
+        if args.download_only:
+            logger.info("Download-only mode. Tarball saved to: %s", output_path)
+            return
+
+    # Extract all NDJSON files
+    ndjson_paths = extract_ndjson_from_tarball(output_path)
+
+    # Count lines across all NDJSON files for reference
+    line_count = 0
+    for ndjson_path in ndjson_paths:
+        with open(ndjson_path, encoding="utf-8") as f:
+            file_lines = sum(1 for line in f if line.strip())
+        logger.info("  %s: %d non-empty lines", ndjson_path.name, file_lines)
+        line_count += file_lines
+    logger.info(
+        "Total: %d non-empty lines across %d files", line_count, len(ndjson_paths)
+    )
+
+    # Load into BigQuery (default: batch load job, optional: streaming inserts)
+    if args.streaming_insert:
+        total = load_ndjson_to_bigquery_streaming(
+            ndjson_paths,
+            project=args.project,
+            dataset=args.dataset,
+            credentials_path=args.credentials,
+            batch_size=args.batch_size,
+        )
+    else:
+        total = load_ndjson_to_bigquery_load_job(
+            ndjson_paths,
+            project=args.project,
+            dataset=args.dataset,
+            credentials_path=args.credentials,
+        )
+
+    logger.info(
+        "Done! %d rows loaded into %s.%s.%s (from %d NDJSON lines in %d files)",
+        total,
+        args.project,
+        args.dataset,
+        BQ_TABLE_ID,
+        line_count,
+        len(ndjson_paths),
+    )
+
+    if total < line_count:
+        logger.warning(
+            "INCOMPLETE: only %d of %d lines were loaded. "
+            "Check logs above for parse errors or BigQuery insert failures.",
+            total,
+            line_count,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mwlib/apps/fetch_wikimedia_snapshot.py
+++ b/src/mwlib/apps/fetch_wikimedia_snapshot.py
@@ -37,6 +37,7 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import sys
 import tarfile
 import tempfile
@@ -142,9 +143,7 @@ def get_bearer_token(username: str, password: str) -> str:
     resp.raise_for_status()
     data = resp.json()
     token = data["access_token"]
-    logger.info(
-        "Authentication successful (token expires in %ss)", data.get("expires_in")
-    )
+    logger.info("Authentication successful (token expires in %ss)", data.get("expires_in"))
     return token
 
 
@@ -169,9 +168,7 @@ def download_snapshot_streaming(
     Verifies download completeness by comparing bytes received to Content-Length.
     """
     url = f"{WME_API_BASE}/snapshots/{snapshot_id}/download"
-    logger.info(
-        "Downloading snapshot %s to %s (streaming)...", snapshot_id, output_path
-    )
+    logger.info("Downloading snapshot %s to %s (streaming)...", snapshot_id, output_path)
 
     resp = requests.get(
         url,
@@ -194,9 +191,7 @@ def download_snapshot_streaming(
             if downloaded - last_logged >= _DOWNLOAD_LOG_INTERVAL:
                 if total > 0:
                     pct = 100.0 * downloaded / total
-                    logger.info(
-                        "  %.1f%% (%d / %d MB)", pct, downloaded >> 20, total >> 20
-                    )
+                    logger.info("  %.1f%% (%d / %d MB)", pct, downloaded >> 20, total >> 20)
                 else:
                     logger.info("  %d MB downloaded", downloaded >> 20)
                 last_logged = downloaded
@@ -219,9 +214,16 @@ def download_snapshot_streaming(
 
 
 def extract_ndjson_from_tarball(tarball_path: Path) -> list[Path]:
-    """Extract all .ndjson files from a gzipped tarball.
+    """Extract all .ndjson regular-file members from a gzipped tarball.
 
     Returns a list of paths to the extracted NDJSON files.
+
+    A crafted tarball could otherwise smuggle in symlinks, hardlinks,
+    devices, or absolute / parent-traversal paths and trick ``tar.extract``
+    into writing or reading outside ``extract_dir``. We reject anything
+    that isn't a regular file up front and then stream the bytes through
+    ``shutil.copyfileobj`` rather than handing the member to
+    ``tarfile.extract``.
     """
     logger.info("Extracting NDJSON files from %s...", tarball_path)
     extract_dir = tarball_path.parent
@@ -231,15 +233,24 @@ def extract_ndjson_from_tarball(tarball_path: Path) -> list[Path]:
         if not ndjson_members:
             raise ValueError(f"No .ndjson files found in {tarball_path}")
 
-        # Path traversal guard
         for m in ndjson_members:
-            if Path(m.name).is_absolute() or ".." in Path(m.name).parts:
+            p = Path(m.name)
+            if p.is_absolute() or ".." in p.parts:
                 raise ValueError(f"Suspicious tar member path: {m.name}")
+            if not m.isfile():
+                raise ValueError(
+                    f"Refusing to extract non-regular tar member: {m.name} (type={m.type!r})"
+                )
 
         extracted = []
         for member in ndjson_members:
-            tar.extract(member, path=extract_dir)
+            src = tar.extractfile(member)
+            if src is None:
+                raise ValueError(f"Cannot extract tar member: {member.name}")
             path = extract_dir / member.name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with src, open(path, "wb") as dst:
+                shutil.copyfileobj(src, dst)
             logger.info("Extracted: %s (%d bytes)", path, member.size)
             extracted.append(path)
 
@@ -342,9 +353,7 @@ def load_ndjson_to_bigquery_streaming(
     errors_total = 0
 
     for file_idx, ndjson_path in enumerate(ndjson_paths, 1):
-        logger.info(
-            "Processing file %d/%d: %s", file_idx, len(ndjson_paths), ndjson_path
-        )
+        logger.info("Processing file %d/%d: %s", file_idx, len(ndjson_paths), ndjson_path)
         batch = []
 
         with open(ndjson_path, encoding="utf-8") as f:
@@ -361,9 +370,7 @@ def load_ndjson_to_bigquery_streaming(
                 batch.append(row)
 
                 if len(batch) >= batch_size:
-                    inserted, failed = _insert_batch_with_retry(
-                        client, table_ref, batch
-                    )
+                    inserted, failed = _insert_batch_with_retry(client, table_ref, batch)
                     total_rows += inserted
                     errors_total += failed
                     logger.info(
@@ -395,9 +402,7 @@ def load_ndjson_to_bigquery_streaming(
     return total_rows
 
 
-def _insert_batch_with_retry(
-    client, table_ref: str, batch: list[dict]
-) -> tuple[int, int]:
+def _insert_batch_with_retry(client, table_ref: str, batch: list[dict]) -> tuple[int, int]:
     """Insert a batch of rows, retrying failed rows once.
 
     Returns (inserted_count, failed_count).
@@ -461,9 +466,7 @@ def load_ndjson_to_bigquery_load_job(
     skipped_rows = 0
     try:
         total_rows = 0
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".ndjson", delete=False
-        ) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".ndjson", delete=False) as tmp:
             tmp_path = tmp.name
             for file_idx, ndjson_path in enumerate(ndjson_paths, 1):
                 logger.info(
@@ -615,9 +618,7 @@ def main():
         username = os.environ.get("WME_USERNAME")
         password = os.environ.get("WME_PASSWORD")
         if not username or not password:
-            logger.error(
-                "WME_USERNAME and WME_PASSWORD environment variables are required"
-            )
+            logger.error("WME_USERNAME and WME_PASSWORD environment variables are required")
             sys.exit(1)
 
         token = get_bearer_token(username, password)
@@ -650,9 +651,7 @@ def main():
             file_lines = sum(1 for line in f if line.strip())
         logger.info("  %s: %d non-empty lines", ndjson_path.name, file_lines)
         line_count += file_lines
-    logger.info(
-        "Total: %d non-empty lines across %d files", line_count, len(ndjson_paths)
-    )
+    logger.info("Total: %d non-empty lines across %d files", line_count, len(ndjson_paths))
 
     # Load into BigQuery (default: batch load job, optional: streaming inserts)
     if args.streaming_insert:

--- a/src/mwlib/apps/fetch_wikimedia_snapshot.py
+++ b/src/mwlib/apps/fetch_wikimedia_snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fetch Wikimedia Enterprise namespace 6 snapshot and load into BigQuery.
+"""Fetch Wikimedia Enterprise namespace snapshots and load them into BigQuery.
 
 Authentication:
     Uses WME_USERNAME / WME_PASSWORD env vars to obtain a bearer token from
@@ -9,24 +9,46 @@ BigQuery:
     Uses GOOGLE_APPLICATION_CREDENTIALS (or the service account JSON path
     passed via --credentials) for authentication.
 
+Namespaces:
+    --namespace 6 (default): NS6 file description pages → ``file_pages`` table.
+        Schema captures dimensions, license, templates, and categories — the
+        fields needed to surface cover candidates and check print eligibility.
+    --namespace 0: NS0 article HTML → ``article_pages`` table. Lean schema
+        (name, identifier, article_body_html, date_modified) sized to keep
+        BigQuery storage cost in line with what the page-count estimator
+        actually consumes. The table is provisioned by Pulumi (clustered on
+        ``name``) — this script never drops or recreates it.
+
+Disk usage:
+    NS0 EN ships as multiple multi-GB NDJSON chunks inside one tarball. Local
+    disk is capped at "tarball + one extracted NDJSON" by extracting members
+    just-in-time and deleting each one after BigQuery has loaded it. Without
+    this, peak disk would be roughly 2× the tarball size.
+
 Data handling:
-    Each run replaces all data in the target table (WRITE_TRUNCATE / drop+create).
-    This is intentional for snapshot ETL — no upsert logic is needed.
+    Each run replaces all data in the target table. The default load-job mode
+    submits one BigQuery load job per NDJSON file (WRITE_TRUNCATE on the first,
+    WRITE_APPEND afterwards) so a single multi-hundred-GB intermediate file is
+    never required. Streaming insert mode is preserved for operators who need
+    it but is significantly more expensive at scale.
 
 Usage examples:
     # List available snapshots
     python fetch_wikimedia_snapshot.py --list
 
-    # Download namespace 6 snapshot only (no BigQuery load)
-    python fetch_wikimedia_snapshot.py --download-only -o enwiki_ns6.tar.gz
-
-    # Full pipeline: download + load into BigQuery (default: batch load job)
+    # Default: download + load NS6 (file_pages)
     python fetch_wikimedia_snapshot.py --project pediapress-prod --dataset wikipedia
 
-    # Load from an already-downloaded tarball (skip download)
-    python fetch_wikimedia_snapshot.py -i /path/to/enwiki_ns6.tar.gz
+    # Download + load NS0 (article_pages, EN article HTML)
+    python fetch_wikimedia_snapshot.py --namespace 0 --project pediapress-prod
 
-    # Use streaming inserts instead of batch load job
+    # Download only — useful for inspecting a snapshot before loading
+    python fetch_wikimedia_snapshot.py --namespace 0 --download-only -o enwiki_ns0.tar.gz
+
+    # Load from an already-downloaded tarball (skip download)
+    python fetch_wikimedia_snapshot.py --namespace 0 -i /path/to/enwiki_ns0.tar.gz
+
+    # Use streaming inserts instead of batch load jobs
     python fetch_wikimedia_snapshot.py --streaming-insert --project pediapress-prod
 """
 
@@ -41,6 +63,8 @@ import shutil
 import sys
 import tarfile
 import tempfile
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
 import requests
@@ -53,13 +77,11 @@ logger = logging.getLogger(__name__)
 
 WME_AUTH_URL = "https://auth.enterprise.wikimedia.com/v1/login"
 WME_API_BASE = "https://api.enterprise.wikimedia.com/v2"
-DEFAULT_SNAPSHOT_ID = "enwiki_namespace_6"
 
-# BigQuery schema for the namespace 6 file description pages.
-# Focused on fields needed for license checking. article_body_html is omitted
+# BigQuery schema for namespace 6 file description pages.
+# Focused on fields needed for license checking. article_body html is omitted
 # to avoid storage bloat — templates and categories cover license-checking needs.
-BQ_TABLE_ID = "file_pages"
-BQ_SCHEMA = [
+NS6_SCHEMA = [
     {
         "name": "name",
         "type": "STRING",
@@ -128,8 +150,153 @@ BQ_SCHEMA = [
     },
 ]
 
+# BigQuery schema for namespace 0 article HTML.
+# Deliberately minimal: storing full Parsoid HTML for English Wikipedia is the
+# dominant cost in this dataset, so anything we don't need for the R3 page-count
+# estimator (abstract, templates, categories, version metadata, wikitext, etc.)
+# is dropped at ingest time. The table is clustered on ``name`` in Pulumi so
+# point lookups by article title don't scan the whole table.
+NS0_SCHEMA = [
+    {
+        "name": "name",
+        "type": "STRING",
+        "mode": "REQUIRED",
+        "description": "Article title (e.g. 'Mainz')",
+    },
+    {
+        "name": "identifier",
+        "type": "INTEGER",
+        "mode": "NULLABLE",
+        "description": "MediaWiki page ID",
+    },
+    {
+        "name": "date_modified",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE",
+        "description": "Last modification timestamp (for snapshot freshness checks)",
+    },
+    {
+        "name": "article_body_html",
+        "type": "STRING",
+        "mode": "NULLABLE",
+        "description": "Parsoid HTML body — input to the page-count estimator",
+    },
+]
+
 # Progress logging interval (bytes) during download
 _DOWNLOAD_LOG_INTERVAL = 100 * 1024 * 1024  # log every 100 MB
+
+
+def parse_ns6_row(line: str) -> dict | None:
+    """Parse a single NS6 NDJSON line into a BigQuery-compatible row."""
+    try:
+        doc = json.loads(line)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed JSON line: %s...", line[:100])
+        return None
+
+    name = doc.get("name")
+    if not name:
+        logger.warning("Skipping row with missing 'name' field: %s...", line[:100])
+        return None
+
+    row = {
+        "name": name,
+        "identifier": doc.get("identifier"),
+        "url": doc.get("url"),
+        "date_modified": doc.get("date_modified"),
+    }
+
+    # Serialize complex fields as JSON strings for BigQuery JSON columns
+    if "license" in doc and doc["license"]:
+        row["license"] = json.dumps(doc["license"])
+    if "templates" in doc and doc["templates"]:
+        row["templates"] = json.dumps(doc["templates"])
+    if "categories" in doc and doc["categories"]:
+        row["categories"] = json.dumps(doc["categories"])
+
+    row["abstract"] = doc.get("abstract")
+
+    image = doc.get("image")
+    if image and isinstance(image, dict):
+        row["image_content_url"] = image.get("content_url")
+        row["image_width"] = image.get("width")
+        row["image_height"] = image.get("height")
+
+    return row
+
+
+def parse_ns0_row(line: str) -> dict | None:
+    """Parse a single NS0 NDJSON line into a lean BigQuery row.
+
+    Drops every field except (name, identifier, date_modified, article_body_html).
+    Rows missing ``article_body.html`` are skipped — they can't serve any R3
+    query, and storing empty placeholders just bloats a table that already
+    runs to hundreds of GB.
+    """
+    try:
+        doc = json.loads(line)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed JSON line: %s...", line[:100])
+        return None
+
+    name = doc.get("name")
+    if not name:
+        logger.warning("Skipping row with missing 'name' field: %s...", line[:100])
+        return None
+
+    article_body = doc.get("article_body")
+    html = None
+    if isinstance(article_body, dict):
+        html = article_body.get("html")
+    if not html:
+        return None
+
+    return {
+        "name": name,
+        "identifier": doc.get("identifier"),
+        "date_modified": doc.get("date_modified"),
+        "article_body_html": html,
+    }
+
+
+@dataclass(frozen=True)
+class NamespaceConfig:
+    """Per-namespace configuration: snapshot, target table, schema, parser.
+
+    ``script_manages_table`` is True for tables this script creates and
+    recreates on each run (NS6 — the legacy behaviour, preserved to avoid
+    regressions). It is False for tables provisioned externally (NS0 —
+    declared in Pulumi); for those, the script only loads data and never
+    drops the table.
+    """
+
+    namespace: int
+    snapshot_id: str
+    table_id: str
+    schema: list[dict]
+    parser: Callable[[str], dict | None]
+    script_manages_table: bool
+
+
+NAMESPACES: dict[int, NamespaceConfig] = {
+    6: NamespaceConfig(
+        namespace=6,
+        snapshot_id="enwiki_namespace_6",
+        table_id="file_pages",
+        schema=NS6_SCHEMA,
+        parser=parse_ns6_row,
+        script_manages_table=True,
+    ),
+    0: NamespaceConfig(
+        namespace=0,
+        snapshot_id="enwiki_namespace_0",
+        table_id="article_pages",
+        schema=NS0_SCHEMA,
+        parser=parse_ns0_row,
+        script_manages_table=False,
+    ),
+}
 
 
 def get_bearer_token(username: str, password: str) -> str:
@@ -196,7 +363,6 @@ def download_snapshot_streaming(
                     logger.info("  %d MB downloaded", downloaded >> 20)
                 last_logged = downloaded
 
-    # Verify completeness
     if total > 0 and downloaded != total:
         os.unlink(output_path)
         raise RuntimeError(
@@ -213,37 +379,51 @@ def download_snapshot_streaming(
     return output_path
 
 
-def extract_ndjson_from_tarball(tarball_path: Path) -> list[Path]:
-    """Extract all .ndjson regular-file members from a gzipped tarball.
-
-    Returns a list of paths to the extracted NDJSON files.
+def _validate_tar_member(member: tarfile.TarInfo) -> None:
+    """Reject anything that isn't a regular file at a safe relative path.
 
     A crafted tarball could otherwise smuggle in symlinks, hardlinks,
-    devices, or absolute / parent-traversal paths and trick ``tar.extract``
-    into writing or reading outside ``extract_dir``. We reject anything
-    that isn't a regular file up front and then stream the bytes through
-    ``shutil.copyfileobj`` rather than handing the member to
-    ``tarfile.extract``.
+    devices, or absolute / parent-traversal paths and trick
+    ``tar.extract`` into writing or reading outside ``extract_dir``.
+    Combined with the ``shutil.copyfileobj`` extraction below, this
+    ensures we only ever materialise plain regular files at relative
+    paths under the tarball's parent directory.
     """
-    logger.info("Extracting NDJSON files from %s...", tarball_path)
+    name = member.name
+    p = Path(name)
+    if p.is_absolute() or ".." in p.parts:
+        raise ValueError(f"Suspicious tar member path: {name}")
+    if not member.isfile():
+        raise ValueError(
+            f"Refusing to extract non-regular tar member: {name} (type={member.type!r})"
+        )
+
+
+def iter_extract_ndjson(tarball_path: Path) -> Iterator[Path]:
+    """Yield each .ndjson member of the tarball, extracting just-in-time.
+
+    The previously yielded NDJSON is unlinked before the next is extracted
+    (and the last one is unlinked when the iterator finishes), so peak local
+    disk usage stays at "tarball + at most one extracted NDJSON" rather than
+    "tarball + every NDJSON". For NS0 EN this is the difference between a
+    feasible sync and one that needs a TB of free disk.
+
+    Members are validated as regular files at relative paths and then
+    streamed via ``shutil.copyfileobj`` rather than handed to
+    ``tar.extract`` — see ``_validate_tar_member``.
+    """
     extract_dir = tarball_path.parent
 
     with tarfile.open(tarball_path, "r:gz") as tar:
-        ndjson_members = [m for m in tar.getmembers() if m.name.endswith(".ndjson")]
-        if not ndjson_members:
+        members = [m for m in tar.getmembers() if m.name.endswith(".ndjson")]
+        if not members:
             raise ValueError(f"No .ndjson files found in {tarball_path}")
+        for m in members:
+            _validate_tar_member(m)
 
-        for m in ndjson_members:
-            p = Path(m.name)
-            if p.is_absolute() or ".." in p.parts:
-                raise ValueError(f"Suspicious tar member path: {m.name}")
-            if not m.isfile():
-                raise ValueError(
-                    f"Refusing to extract non-regular tar member: {m.name} (type={m.type!r})"
-                )
+        logger.info("Tarball contains %d NDJSON files; will extract one at a time", len(members))
 
-        extracted = []
-        for member in ndjson_members:
+        for idx, member in enumerate(members, 1):
             src = tar.extractfile(member)
             if src is None:
                 raise ValueError(f"Cannot extract tar member: {member.name}")
@@ -251,51 +431,16 @@ def extract_ndjson_from_tarball(tarball_path: Path) -> list[Path]:
             path.parent.mkdir(parents=True, exist_ok=True)
             with src, open(path, "wb") as dst:
                 shutil.copyfileobj(src, dst)
-            logger.info("Extracted: %s (%d bytes)", path, member.size)
-            extracted.append(path)
-
-        logger.info("Extracted %d NDJSON files", len(extracted))
-        return extracted
-
-
-def parse_ndjson_row(line: str) -> dict | None:
-    """Parse a single NDJSON line into a BigQuery-compatible row."""
-    try:
-        doc = json.loads(line)
-    except json.JSONDecodeError:
-        logger.warning("Skipping malformed JSON line: %s...", line[:100])
-        return None
-
-    name = doc.get("name")
-    if not name:
-        logger.warning("Skipping row with missing 'name' field: %s...", line[:100])
-        return None
-
-    row = {
-        "name": name,
-        "identifier": doc.get("identifier"),
-        "url": doc.get("url"),
-        "date_modified": doc.get("date_modified"),
-    }
-
-    # Serialize complex fields as JSON strings for BigQuery JSON columns
-    if "license" in doc and doc["license"]:
-        row["license"] = json.dumps(doc["license"])
-    if "templates" in doc and doc["templates"]:
-        row["templates"] = json.dumps(doc["templates"])
-    if "categories" in doc and doc["categories"]:
-        row["categories"] = json.dumps(doc["categories"])
-
-    row["abstract"] = doc.get("abstract")
-
-    # Extract image metadata
-    image = doc.get("image")
-    if image and isinstance(image, dict):
-        row["image_content_url"] = image.get("content_url")
-        row["image_width"] = image.get("width")
-        row["image_height"] = image.get("height")
-
-    return row
+            logger.info("Extracted %d/%d: %s (%d bytes)", idx, len(members), path, member.size)
+            try:
+                yield path
+            finally:
+                if path.exists():
+                    try:
+                        path.unlink()
+                        logger.info("Removed extracted NDJSON: %s", path)
+                    except OSError:
+                        logger.exception("Failed to clean up %s", path)
 
 
 def _make_bq_client(project: str, credentials_path: str | None):
@@ -309,8 +454,8 @@ def _make_bq_client(project: str, credentials_path: str | None):
     return bigquery.Client(project=project)
 
 
-def _make_bq_schema():
-    """Build a list of BigQuery SchemaField objects from BQ_SCHEMA."""
+def _make_bq_schema(schema: list[dict]):
+    """Build a list of BigQuery SchemaField objects from a schema spec."""
     from google.cloud import bigquery
 
     return [
@@ -320,86 +465,32 @@ def _make_bq_schema():
             mode=f["mode"],
             description=f.get("description", ""),
         )
-        for f in BQ_SCHEMA
+        for f in schema
     ]
 
 
-def load_ndjson_to_bigquery_streaming(
-    ndjson_paths: list[Path],
-    project: str,
-    dataset: str,
-    credentials_path: str | None = None,
-    batch_size: int = 10_000,
-) -> int:
-    """Load parsed NDJSON rows into BigQuery using the streaming insert API.
+def _prepare_table(client, table_ref: str, ns: NamespaceConfig) -> None:
+    """Ensure the destination table exists with the right schema.
 
-    Processes all NDJSON files in order. Failed rows are retried once.
-
-    Returns the total number of rows successfully loaded.
+    For script-managed namespaces (NS6) the table is recreated on every run —
+    that's the long-standing behaviour and keeps schema changes effortless.
+    For externally-managed tables (NS0 → Pulumi) the script never drops the
+    table; it just verifies it exists. ``exists_ok=True`` makes the call a
+    no-op when Pulumi has already created it, which is the production case,
+    while still letting the script bootstrap a missing table in dev.
     """
-    client = _make_bq_client(project, credentials_path)
-    table_ref = f"{project}.{dataset}.{BQ_TABLE_ID}"
-
-    schema = _make_bq_schema()
     from google.cloud import bigquery
 
+    schema = _make_bq_schema(ns.schema)
     table = bigquery.Table(table_ref, schema=schema)
-    client.delete_table(table_ref, not_found_ok=True)
-    client.create_table(table)
-    logger.info("Created BigQuery table %s", table_ref)
 
-    total_rows = 0
-    skipped_rows = 0
-    errors_total = 0
-
-    for file_idx, ndjson_path in enumerate(ndjson_paths, 1):
-        logger.info("Processing file %d/%d: %s", file_idx, len(ndjson_paths), ndjson_path)
-        batch = []
-
-        with open(ndjson_path, encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-
-                row = parse_ndjson_row(line)
-                if row is None:
-                    skipped_rows += 1
-                    continue
-
-                batch.append(row)
-
-                if len(batch) >= batch_size:
-                    inserted, failed = _insert_batch_with_retry(client, table_ref, batch)
-                    total_rows += inserted
-                    errors_total += failed
-                    logger.info(
-                        "Loaded %d rows (%d total, %d errors so far)...",
-                        inserted,
-                        total_rows,
-                        errors_total,
-                    )
-                    batch = []
-
-        # Final batch for this file
-        if batch:
-            inserted, failed = _insert_batch_with_retry(client, table_ref, batch)
-            total_rows += inserted
-            errors_total += failed
-
-    logger.info(
-        "Load complete: %d rows loaded from %d files, %d errors, %d skipped",
-        total_rows,
-        len(ndjson_paths),
-        errors_total,
-        skipped_rows,
-    )
-    if errors_total > 0:
-        logger.error(
-            "WARNING: %d rows failed to insert. The table may be incomplete.",
-            errors_total,
-        )
-    return total_rows
+    if ns.script_manages_table:
+        client.delete_table(table_ref, not_found_ok=True)
+        client.create_table(table)
+        logger.info("Created BigQuery table %s", table_ref)
+    else:
+        client.create_table(table, exists_ok=True)
+        logger.info("Using BigQuery table %s (managed externally)", table_ref)
 
 
 def _insert_batch_with_retry(client, table_ref: str, batch: list[dict]) -> tuple[int, int]:
@@ -411,7 +502,6 @@ def _insert_batch_with_retry(client, table_ref: str, batch: list[dict]) -> tuple
     if not errors:
         return len(batch), 0
 
-    # Identify which rows failed
     failed_indices = set()
     for err in errors:
         idx = err.get("index")
@@ -421,20 +511,17 @@ def _insert_batch_with_retry(client, table_ref: str, batch: list[dict]) -> tuple
             logger.warning("  Insert error: %s", detail)
 
     if not failed_indices:
-        # Can't determine which rows failed — count all as failed
         logger.warning("Insert returned %d errors but no row indices", len(errors))
         return 0, len(batch)
 
     succeeded = len(batch) - len(failed_indices)
 
-    # Retry failed rows once
     retry_batch = [batch[i] for i in sorted(failed_indices)]
     logger.info("Retrying %d failed rows...", len(retry_batch))
     retry_errors = client.insert_rows_json(table_ref, retry_batch)
     if not retry_errors:
         return len(batch), 0
 
-    # Log permanently failed rows
     permanent_failures = len(retry_errors)
     for err in retry_errors[:3]:
         logger.error("Permanent insert failure: %s", err)
@@ -442,64 +529,104 @@ def _insert_batch_with_retry(client, table_ref: str, batch: list[dict]) -> tuple
     return succeeded + (len(retry_batch) - permanent_failures), permanent_failures
 
 
-def load_ndjson_to_bigquery_load_job(
-    ndjson_paths: list[Path],
-    project: str,
-    dataset: str,
-    credentials_path: str | None = None,
-) -> int:
-    """Load NDJSON into BigQuery using a load job (better for large files).
+def _stream_one_file(
+    *,
+    client,
+    table_ref: str,
+    ndjson_path: Path,
+    parser: Callable[[str], dict | None],
+    batch_size: int,
+) -> tuple[int, int]:
+    """Stream one NDJSON file's rows into BigQuery via insert_rows_json.
 
-    Reads all NDJSON files, converts each line to our schema, writes to a
-    single temporary file, then uses a BigQuery load job with WRITE_TRUNCATE.
+    Returns (rows_inserted, rows_skipped).
+    """
+    inserted_total = 0
+    skipped = 0
+    errors_total = 0
+    batch: list[dict] = []
 
-    Returns the total number of rows loaded.
+    with open(ndjson_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            row = parser(line)
+            if row is None:
+                skipped += 1
+                continue
+            batch.append(row)
+            if len(batch) >= batch_size:
+                inserted, failed = _insert_batch_with_retry(client, table_ref, batch)
+                inserted_total += inserted
+                errors_total += failed
+                logger.info(
+                    "  Streamed %d rows (%d total, %d errors so far)",
+                    inserted,
+                    inserted_total,
+                    errors_total,
+                )
+                batch = []
+
+    if batch:
+        inserted, failed = _insert_batch_with_retry(client, table_ref, batch)
+        inserted_total += inserted
+        errors_total += failed
+
+    if errors_total > 0:
+        logger.error(
+            "WARNING: %d rows failed to insert from %s. Table may be incomplete.",
+            errors_total,
+            ndjson_path.name,
+        )
+    return inserted_total, skipped
+
+
+def _load_one_file(
+    *,
+    client,
+    ndjson_path: Path,
+    file_idx: int,
+    table_ref: str,
+    schema,
+    parser: Callable[[str], dict | None],
+    write_disposition,
+) -> tuple[int, int]:
+    """Stream-transform one NDJSON file and submit it as a single load job.
+
+    Returns (rows_loaded, rows_skipped).
     """
     from google.cloud import bigquery
 
-    client = _make_bq_client(project, credentials_path)
-    table_ref = f"{project}.{dataset}.{BQ_TABLE_ID}"
-    schema = _make_bq_schema()
+    logger.info("Preparing NDJSON file %d: %s", file_idx, ndjson_path)
 
-    # Write transformed rows from ALL files to a single temp NDJSON file
     tmp_path = None
-    skipped_rows = 0
     try:
-        total_rows = 0
+        prepared = 0
+        skipped = 0
         with tempfile.NamedTemporaryFile(mode="w", suffix=".ndjson", delete=False) as tmp:
             tmp_path = tmp.name
-            for file_idx, ndjson_path in enumerate(ndjson_paths, 1):
-                logger.info(
-                    "Preparing file %d/%d: %s",
-                    file_idx,
-                    len(ndjson_paths),
-                    ndjson_path,
-                )
-                with open(ndjson_path, encoding="utf-8") as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        row = parse_ndjson_row(line)
-                        if row is None:
-                            skipped_rows += 1
-                            continue
-                        tmp.write(json.dumps(row) + "\n")
-                        total_rows += 1
+            with open(ndjson_path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    row = parser(line)
+                    if row is None:
+                        skipped += 1
+                        continue
+                    tmp.write(json.dumps(row) + "\n")
+                    prepared += 1
 
-        logger.info(
-            "Prepared %d rows from %d files for BigQuery load job (%d skipped)",
-            total_rows,
-            len(ndjson_paths),
-            skipped_rows,
-        )
+        if prepared == 0:
+            logger.warning("File %d produced 0 rows after parsing; skipping load job", file_idx)
+            return 0, skipped
 
-        # Configure load job
         job_config = bigquery.LoadJobConfig(
             schema=schema,
             source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
-            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
-            max_bad_records=0,  # Fail on any bad record
+            write_disposition=write_disposition,
+            max_bad_records=0,
         )
 
         with open(tmp_path, "rb") as source:
@@ -509,37 +636,123 @@ def load_ndjson_to_bigquery_load_job(
                 job_config=job_config,
             )
 
-        logger.info("BigQuery load job started: %s", load_job.job_id)
-        load_job.result()  # Wait for completion
+        logger.info(
+            "BigQuery load job started for file %d: %s (%d rows prepared)",
+            file_idx,
+            load_job.job_id,
+            prepared,
+        )
+        load_job.result()
 
-        # Check for errors in the load job
         if load_job.errors:
             logger.error("BigQuery load job completed with errors:")
             for err in load_job.errors:
                 logger.error("  %s", err)
 
         loaded = load_job.output_rows
-        logger.info("BigQuery load job completed: %d rows loaded", loaded)
+        logger.info(
+            "Loaded %d rows from file %d (%d prepared, %d skipped)",
+            loaded,
+            file_idx,
+            prepared,
+            skipped,
+        )
 
-        if loaded != total_rows:
+        if loaded != prepared:
             logger.warning(
-                "Row count mismatch: prepared %d rows but BigQuery loaded %d. "
-                "%d rows may have been rejected.",
-                total_rows,
+                "Row count mismatch in file %d: prepared %d, BigQuery loaded %d",
+                file_idx,
+                prepared,
                 loaded,
-                total_rows - loaded,
             )
 
-        return loaded
+        return loaded, skipped
 
     finally:
         if tmp_path and Path(tmp_path).exists():
             os.unlink(tmp_path)
 
 
-def main():
+def load_tarball_to_bigquery(
+    tarball_path: Path,
+    *,
+    project: str,
+    dataset: str,
+    ns: NamespaceConfig,
+    credentials_path: str | None = None,
+    use_streaming_insert: bool = False,
+    batch_size: int = 10_000,
+) -> tuple[int, int]:
+    """Stream-extract a tarball into BigQuery, one NDJSON file at a time.
+
+    Caps local disk usage at "tarball + at most one extracted NDJSON" — the
+    iterator deletes each NDJSON immediately after the load job (or streaming
+    batch) for it has finished.
+
+    Returns ``(rows_loaded, rows_skipped)``.
+    """
+    from google.cloud import bigquery
+
+    client = _make_bq_client(project, credentials_path)
+    table_ref = f"{project}.{dataset}.{ns.table_id}"
+    _prepare_table(client, table_ref, ns)
+
+    schema = None
+    if use_streaming_insert:
+        # Streaming inserts append, so for externally managed tables we must
+        # explicitly clear the previous run's data first. ``_prepare_table``
+        # already truncated implicitly for script-managed tables (drop+create),
+        # so the TRUNCATE here is only needed for the Pulumi-managed case.
+        if not ns.script_manages_table:
+            logger.info("Truncating %s before streaming inserts", table_ref)
+            client.query(f"TRUNCATE TABLE `{table_ref}`").result()
+    else:
+        schema = _make_bq_schema(ns.schema)
+
+    total_loaded = 0
+    total_skipped = 0
+    file_idx = 0
+
+    for ndjson_path in iter_extract_ndjson(tarball_path):
+        file_idx += 1
+        if use_streaming_insert:
+            loaded, skipped = _stream_one_file(
+                client=client,
+                table_ref=table_ref,
+                ndjson_path=ndjson_path,
+                parser=ns.parser,
+                batch_size=batch_size,
+            )
+        else:
+            write_disposition = (
+                bigquery.WriteDisposition.WRITE_TRUNCATE
+                if file_idx == 1
+                else bigquery.WriteDisposition.WRITE_APPEND
+            )
+            loaded, skipped = _load_one_file(
+                client=client,
+                ndjson_path=ndjson_path,
+                file_idx=file_idx,
+                table_ref=table_ref,
+                schema=schema,
+                parser=ns.parser,
+                write_disposition=write_disposition,
+            )
+        total_loaded += loaded
+        total_skipped += skipped
+
+    logger.info(
+        "Load complete: %d rows loaded across %d files (%d skipped)",
+        total_loaded,
+        file_idx,
+        total_skipped,
+    )
+    return total_loaded, total_skipped
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Fetch Wikimedia Enterprise namespace 6 snapshot and load into BigQuery.",
+        description=("Fetch a Wikimedia Enterprise namespace snapshot and load it into BigQuery."),
     )
     parser.add_argument(
         "--list",
@@ -547,9 +760,28 @@ def main():
         help="List available snapshots and exit",
     )
     parser.add_argument(
+        "--namespace",
+        type=int,
+        choices=sorted(NAMESPACES),
+        default=6,
+        help=(
+            "Wikipedia namespace to sync. 6 = file description pages "
+            "(file_pages table). 0 = article HTML (article_pages table). "
+            "Default: 6."
+        ),
+    )
+    parser.add_argument(
         "--download-only",
         action="store_true",
         help="Download the snapshot but skip BigQuery loading",
+    )
+    parser.add_argument(
+        "--keep-tarball",
+        action="store_true",
+        help=(
+            "Keep the downloaded tarball after BigQuery loading completes "
+            "(default: delete to free disk)."
+        ),
     )
     parser.add_argument(
         "--streaming-insert",
@@ -558,8 +790,11 @@ def main():
     )
     parser.add_argument(
         "--snapshot-id",
-        default=DEFAULT_SNAPSHOT_ID,
-        help=f"Snapshot identifier (default: {DEFAULT_SNAPSHOT_ID})",
+        default=None,
+        help=(
+            "Snapshot identifier override. Defaults to the namespace-derived "
+            "snapshot (enwiki_namespace_6 / enwiki_namespace_0)."
+        ),
     )
     parser.add_argument(
         "-i",
@@ -592,10 +827,16 @@ def main():
         default=10_000,
         help="Rows per batch for streaming inserts (default: 10000)",
     )
+    return parser
 
-    args = parser.parse_args()
 
-    # Load .env if present
+def main(argv: list[str] | None = None) -> int | None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    ns = NAMESPACES[args.namespace]
+    snapshot_id = args.snapshot_id or ns.snapshot_id
+
     try:
         from dotenv import load_dotenv
 
@@ -606,15 +847,17 @@ def main():
     except ImportError:
         pass
 
-    # Use existing tarball or download a new one
+    # The script can either reuse a tarball provided on disk or download a
+    # new one from WME. ``downloaded_here`` tracks whether *this* run owns
+    # the tarball — operator-supplied tarballs (-i) are never deleted.
+    downloaded_here = False
     if args.input:
-        output_path = Path(args.input)
-        if not output_path.exists():
-            logger.error("Input file not found: %s", output_path)
+        tarball_path = Path(args.input)
+        if not tarball_path.exists():
+            logger.error("Input file not found: %s", tarball_path)
             sys.exit(1)
-        logger.info("Using existing tarball: %s", output_path)
+        logger.info("Using existing tarball: %s", tarball_path)
     else:
-        # Authenticate with Wikimedia Enterprise
         username = os.environ.get("WME_USERNAME")
         password = os.environ.get("WME_PASSWORD")
         if not username or not password:
@@ -623,71 +866,50 @@ def main():
 
         token = get_bearer_token(username, password)
 
-        # --list mode
         if args.list:
             snapshots = list_snapshots(token)
             print(json.dumps(snapshots, indent=2))
-            return
+            return None
 
-        # Download snapshot
         if args.output:
-            output_path = Path(args.output)
+            tarball_path = Path(args.output)
         else:
-            output_path = Path(tempfile.mkdtemp()) / f"{args.snapshot_id}.tar.gz"
+            tarball_path = Path(tempfile.mkdtemp()) / f"{snapshot_id}.tar.gz"
 
-        download_snapshot_streaming(token, args.snapshot_id, output_path)
+        download_snapshot_streaming(token, snapshot_id, tarball_path)
+        downloaded_here = True
 
         if args.download_only:
-            logger.info("Download-only mode. Tarball saved to: %s", output_path)
-            return
+            logger.info("Download-only mode. Tarball saved to: %s", tarball_path)
+            return None
 
-    # Extract all NDJSON files
-    ndjson_paths = extract_ndjson_from_tarball(output_path)
-
-    # Count lines across all NDJSON files for reference
-    line_count = 0
-    for ndjson_path in ndjson_paths:
-        with open(ndjson_path, encoding="utf-8") as f:
-            file_lines = sum(1 for line in f if line.strip())
-        logger.info("  %s: %d non-empty lines", ndjson_path.name, file_lines)
-        line_count += file_lines
-    logger.info("Total: %d non-empty lines across %d files", line_count, len(ndjson_paths))
-
-    # Load into BigQuery (default: batch load job, optional: streaming inserts)
-    if args.streaming_insert:
-        total = load_ndjson_to_bigquery_streaming(
-            ndjson_paths,
+    try:
+        loaded, skipped = load_tarball_to_bigquery(
+            tarball_path,
             project=args.project,
             dataset=args.dataset,
+            ns=ns,
             credentials_path=args.credentials,
+            use_streaming_insert=args.streaming_insert,
             batch_size=args.batch_size,
         )
-    else:
-        total = load_ndjson_to_bigquery_load_job(
-            ndjson_paths,
-            project=args.project,
-            dataset=args.dataset,
-            credentials_path=args.credentials,
-        )
+    finally:
+        if downloaded_here and not args.keep_tarball and tarball_path.exists():
+            try:
+                tarball_path.unlink()
+                logger.info("Removed downloaded tarball: %s", tarball_path)
+            except OSError:
+                logger.exception("Failed to remove tarball %s", tarball_path)
 
     logger.info(
-        "Done! %d rows loaded into %s.%s.%s (from %d NDJSON lines in %d files)",
-        total,
+        "Done! %d rows loaded into %s.%s.%s (%d rows skipped)",
+        loaded,
         args.project,
         args.dataset,
-        BQ_TABLE_ID,
-        line_count,
-        len(ndjson_paths),
+        ns.table_id,
+        skipped,
     )
-
-    if total < line_count:
-        logger.warning(
-            "INCOMPLETE: only %d of %d lines were loaded. "
-            "Check logs above for parse errors or BigQuery insert failures.",
-            total,
-            line_count,
-        )
-        sys.exit(1)
+    return None
 
 
 if __name__ == "__main__":

--- a/src/mwlib/core/nuwiki.py
+++ b/src/mwlib/core/nuwiki.py
@@ -115,6 +115,12 @@ class NuWiki:
         else:
             self.imageinfo = DumbJsonDB(file_name, allow_pickle=allow_pickle)
 
+        file_name = os.path.join(self.path, "templates.db")
+        if os.path.exists(file_name):
+            self.templates = DumbJsonDB(file_name, allow_pickle=allow_pickle)
+        else:
+            self.templates = None
+
         self.redirects = self._loadjson("redirects.json", {})
         self.siteinfo = self._loadjson("siteinfo.json", {})
         self.nshandler = nshandling.NsHandler(self.siteinfo)
@@ -280,7 +286,7 @@ class NuWiki:
 
 
 def extract_member(zipfile, member, dstdir):
-    """Copied and adjusted from Python 2.6 stdlib zipfile.py module.
+    """Extract a single member from a zipfile to a destination directory.
 
     Extract the ZipInfo object 'member' to a physical
     file on the path targetpath.
@@ -477,13 +483,26 @@ class Adapt:
         return []
 
     def get_image_templates_and_args(self, name, wikidb=None):
+        # Check pre-extracted templates (from BigQuery) first
+        if self.nuwiki.templates is not None:
+            _, partial, fqname = self.nshandler.splitname(name, nshandling.NS_FILE)
+            for lookup_name in [fqname, self.en_nshandler.get_fqname(partial, nshandling.NS_FILE)]:
+                try:
+                    cached = self.nuwiki.templates[lookup_name]
+                    if cached:
+                        return set(cached)
+                except (KeyError, TypeError, ValueError):
+                    pass
+
+        # Fall back to wikitext parsing
         from mwlib.parser.expander import get_templates
 
         page = self.get_image_description_page(name)
         if page is not None:
             templates = get_templates(page.rawtext)
-            from mwlib.parser.expander import find_template
             from mwlib.parser.templ.evaluate import Expander
+
+            from mwlib.parser.expander import find_template
             from mwlib.parser.templ.misc import DictDB
             from mwlib.parser.templ.parser import parse
 

--- a/src/mwlib/core/nuwiki.py
+++ b/src/mwlib/core/nuwiki.py
@@ -301,9 +301,7 @@ def extract_member(zipfile, member, dstdir):
         raise RuntimeError(f"bad filename in zipfile {targetpath!r}")
 
     # Create all upper directories if necessary.
-    upperdirs = (
-        targetpath if member.filename.endswith("/") else os.path.dirname(targetpath)
-    )
+    upperdirs = targetpath if member.filename.endswith("/") else os.path.dirname(targetpath)
 
     if not os.path.isdir(upperdirs):
         os.makedirs(upperdirs)
@@ -334,8 +332,7 @@ class Adapt:
             self.was_tmpdir = True
 
         if isinstance(path_or_instance, str):
-            self.nuwiki = NuWiki(path_or_instance,
-                                 allow_pickle=not self.was_tmpdir)
+            self.nuwiki = NuWiki(path_or_instance, allow_pickle=not self.was_tmpdir)
         else:
             self.nuwiki = path_or_instance
         self.siteinfo = self.nuwiki.get_siteinfo()
@@ -399,7 +396,6 @@ class Adapt:
             return authors
 
     def get_source(self, title, revision=None):
-
         general_info = self.siteinfo["general"]
         return metabook.Source(
             name="%s (%s)" % (general_info["sitename"], general_info["lang"]),
@@ -465,8 +461,7 @@ class Adapt:
         return self.nuwiki.normalize_and_get_image_path(name)
 
     def get_image_description_page(self, name):
-        _, partial, fqname = self.nshandler.splitname(name,
-                                                      nshandling.NS_FILE)
+        _, partial, fqname = self.nshandler.splitname(name, nshandling.NS_FILE)
         page = self.get_page(fqname)
         if page is not None:
             return page
@@ -483,16 +478,21 @@ class Adapt:
         return []
 
     def get_image_templates_and_args(self, name, wikidb=None):
-        # Check pre-extracted templates (from BigQuery) first
+        # Check pre-extracted templates (from BigQuery) first.
+        # DumbJsonDB returns None for missing keys, so a try/except KeyError
+        # is unnecessary; we just keep walking the candidate names until one
+        # matches, falling through to wikitext parsing if none do.
         if self.nuwiki.templates is not None:
             _, partial, fqname = self.nshandler.splitname(name, nshandling.NS_FILE)
-            for lookup_name in [fqname, self.en_nshandler.get_fqname(partial, nshandling.NS_FILE)]:
-                try:
-                    cached = self.nuwiki.templates[lookup_name]
-                    if cached:
-                        return set(cached)
-                except (KeyError, TypeError, ValueError):
-                    pass
+            for lookup_name in [
+                fqname,
+                self.en_nshandler.get_fqname(partial, nshandling.NS_FILE),
+            ]:
+                cached = self.nuwiki.templates[lookup_name]
+                if cached is not None:
+                    # An empty list is a deliberate negative cache entry —
+                    # honour it and skip the wikitext-parsing fallback.
+                    return set(cached)
 
         # Fall back to wikitext parsing
         from mwlib.parser.expander import get_templates
@@ -500,9 +500,8 @@ class Adapt:
         page = self.get_image_description_page(name)
         if page is not None:
             templates = get_templates(page.rawtext)
-            from mwlib.parser.templ.evaluate import Expander
-
             from mwlib.parser.expander import find_template
+            from mwlib.parser.templ.evaluate import Expander
             from mwlib.parser.templ.misc import DictDB
             from mwlib.parser.templ.parser import parse
 
@@ -514,11 +513,7 @@ class Adapt:
                 tmpl = find_template(None, template, parsed_raw[:])
                 arg_list = tmpl[1]
                 for arg in arg_list:
-                    if (
-                        isinstance(arg, str)
-                        and len(arg) > 3
-                        and " " not in arg
-                    ):
+                    if isinstance(arg, str) and len(arg) > 3 and " " not in arg:
                         args.add(arg)
             templates.update(args)
             return templates
@@ -528,8 +523,7 @@ class Adapt:
         page = self.get_image_description_page(name)
         if page is None:
             return []
-        users = get_contributors_from_information_template(page.rawtext,
-                                                       page.title, self)
+        users = get_contributors_from_information_template(page.rawtext, page.title, self)
         if users:
             return users
         return self.get_authors(page.title)
@@ -538,9 +532,7 @@ class Adapt:
 def get_contributors_from_information_template(raw, title, wikidb):
     def get_user_links(raw):
         def is_user_link(node):
-            return (
-                isinstance(node, parser.NamespaceLink) and node.namespace == 2
-            )  # NS_USER
+            return isinstance(node, parser.NamespaceLink) and node.namespace == 2  # NS_USER
 
         result = sorted(
             {
@@ -566,9 +558,7 @@ def get_contributors_from_information_template(raw, title, wikidb):
                 return [txt]
 
         if args.args:
-            return get_user_links(
-                "\n".join([args.get(i, "") for i in range(len(args.args))])
-            )
+            return get_user_links("\n".join([args.get(i, "") for i in range(len(args.args))]))
 
         return []
 

--- a/src/mwlib/core/nuwiki.py
+++ b/src/mwlib/core/nuwiki.py
@@ -522,7 +522,17 @@ class Adapt:
     def get_contributors(self, name, wikidb=None):
         page = self.get_image_description_page(name)
         if page is None:
-            return []
+            # BigQuery-backed images skip the description-page fetch but
+            # ``Fetcher.get_image_edits`` still populates ``authors.db``
+            # with the remote contributor lookup. Read from there before
+            # falling through to an empty list, otherwise BigQuery hits
+            # would render with no attribution at all.
+            _, partial, fqname = self.nshandler.splitname(name, nshandling.NS_FILE)
+            return (
+                self.get_authors(fqname)
+                or self.get_authors(self.en_nshandler.get_fqname(partial, nshandling.NS_FILE))
+                or []
+            )
         users = get_contributors_from_information_template(page.rawtext, page.title, self)
         if users:
             return users

--- a/src/mwlib/network/auth.py
+++ b/src/mwlib/network/auth.py
@@ -55,8 +55,7 @@ def fetch_and_store_oauth_token(
     except httpx.HTTPError as exc:
         retry_delay = store_oauth_token_failure(token_info_map, domain, token_info, current_time)
         logger.error(
-            f"Failed to fetch OAuth2 token for {domain}: {exc}. "
-            f"Retrying in {retry_delay} seconds."
+            f"Failed to fetch OAuth2 token for {domain}: {exc}. Retrying in {retry_delay} seconds."
         )
         raise RuntimeError(f"Failed to fetch OAuth2 token for {domain}: {exc}") from exc
 
@@ -72,14 +71,46 @@ def ensure_oauth2_token(
     logger,
     current_time_fn,
 ):
+    """Make sure the OAuth2 client has a valid token.
+
+    The token is cached by domain in ``token_info_map``. The OAuth2 client
+    holds its own ``client.token`` attribute that authlib reads when
+    serializing the ``Authorization`` header. The two pieces of state can
+    drift apart — most obviously when the client is invalidated and
+    recreated while the per-domain cache entry is still fresh. If we
+    short-circuit on ``token_info_map`` alone, the new client would send
+    unauthenticated requests.
+
+    Order of operations:
+    1. If the cached entry is fresh and the client already has the same
+       token, return.
+    2. If the cached entry is fresh but the client is missing it, push
+       the cached token onto the client and return.
+    3. Otherwise refetch (subject to backoff).
+    """
     if not enabled:
         return
 
     domain = get_oauth_domain(apiurl)
     current_time = current_time_fn()
     token_info = token_info_map.get(domain, {})
+
     if not token_needs_refresh(token_info, current_time):
-        return
+        cached_token = token_info.get("token")
+        client_token = getattr(http_client, "token", None)
+        if cached_token is not None and client_token == cached_token:
+            return
+        if cached_token is not None:
+            try:
+                http_client.token = cached_token
+                return
+            except Exception:
+                logger.warning(
+                    "Failed to restore cached OAuth token onto client; will refetch",
+                    exc_info=True,
+                )
+                # Fall through to refetch.
+
     if not token_backoff_elapsed(token_info, current_time):
         return
 

--- a/src/mwlib/network/auth.py
+++ b/src/mwlib/network/auth.py
@@ -70,16 +70,21 @@ def ensure_oauth2_token(
     http_client,
     logger,
     current_time_fn,
+    cache_key=None,
 ):
     """Make sure the OAuth2 client has a valid token.
 
-    The token is cached by domain in ``token_info_map``. The OAuth2 client
-    holds its own ``client.token`` attribute that authlib reads when
-    serializing the ``Authorization`` header. The two pieces of state can
-    drift apart — most obviously when the client is invalidated and
-    recreated while the per-domain cache entry is still fresh. If we
-    short-circuit on ``token_info_map`` alone, the new client would send
-    unauthenticated requests.
+    Token state is cached in ``token_info_map`` under ``cache_key``. By
+    default the key is just the API domain, but callers with multiple
+    OAuth configurations against the same wiki (credential rotation,
+    multi-tenant test runs) should pass a key that also captures
+    client identity — otherwise two distinct OAuth configs share each
+    other's access tokens.
+
+    The OAuth2 client also holds its own ``.token`` attribute that
+    authlib reads when serializing the ``Authorization`` header. That
+    state drifts from the cache when the client is invalidated and
+    recreated; reconcile rather than blindly short-circuiting.
 
     Order of operations:
     1. If the cached entry is fresh and the client already has the same
@@ -91,9 +96,9 @@ def ensure_oauth2_token(
     if not enabled:
         return
 
-    domain = get_oauth_domain(apiurl)
+    key = cache_key if cache_key is not None else get_oauth_domain(apiurl)
     current_time = current_time_fn()
-    token_info = token_info_map.get(domain, {})
+    token_info = token_info_map.get(key, {})
 
     if not token_needs_refresh(token_info, current_time):
         cached_token = token_info.get("token")
@@ -115,7 +120,7 @@ def ensure_oauth2_token(
         return
 
     fetch_and_store_oauth_token(
-        domain=domain,
+        domain=key,
         token_info=token_info,
         current_time=current_time,
         token_info_map=token_info_map,

--- a/src/mwlib/network/bigquery_lookup.py
+++ b/src/mwlib/network/bigquery_lookup.py
@@ -109,7 +109,11 @@ class BigQueryImageLookup:
             - rows: List of dicts with BigQuery row data for found titles
             - missing_titles: Titles not found in BigQuery (fall back to remote API)
 
-        On any error, returns ([], titles) so all titles fall back to the remote API.
+        Transient query/runtime errors return ``([], titles)`` so callers
+        can fall back to the remote API. Configuration validation errors
+        (``ValueError`` from ``_validate_bigquery_identifier``) are
+        re-raised — silently swallowing those would hide a deployment or
+        security problem behind a "BigQuery is just slow today" log line.
 
         """
         if not titles or not self._client:
@@ -117,6 +121,11 @@ class BigQueryImageLookup:
 
         try:
             return self._execute_query(titles)
+        except ValueError:
+            # project / dataset / table didn't pass identifier validation;
+            # let that bubble up to the operator instead of pretending
+            # BigQuery is just transiently down.
+            raise
         except Exception:
             logger.warning(
                 "BigQuery lookup failed for %d titles, falling back to remote API",

--- a/src/mwlib/network/bigquery_lookup.py
+++ b/src/mwlib/network/bigquery_lookup.py
@@ -50,8 +50,11 @@ class BigQueryImageLookup:
         self.table = conf.get("bigquery", "table", "file_pages")
         self.timeout = conf.get("bigquery", "timeout", 30, int)
 
+        # Hostnames are case-insensitive; lowercase the configured set so
+        # ``EN.Wikipedia.ORG`` in config still matches ``en.wikipedia.org``
+        # in a parsed URL.
         domains_str = conf.get("bigquery", "domains", "en.wikipedia.org")
-        self.domains = {d.strip() for d in domains_str.split(",") if d.strip()}
+        self.domains = {d.strip().lower() for d in domains_str.split(",") if d.strip()}
 
         self._client = None
         self._init_client()
@@ -80,10 +83,15 @@ class BigQueryImageLookup:
         Uses hostname-exact matching, not substring containment. A naive
         ``"en.wikipedia.org" in path`` would also match attacker-controlled
         hosts like ``en.wikipedia.org.example.com`` or unrelated query
-        strings. Anything that fails to parse as a URL is treated as a
-        bare hostname for the convenience of callers who pass either form.
+        strings. ``.hostname`` (rather than ``.netloc``) is what we want
+        because it lowercases automatically and strips both ``user:pass@``
+        and trailing ``:port`` — so ``https://en.wikipedia.org:443/x`` and
+        ``https://EN.WIKIPEDIA.ORG/x`` both resolve to the same host.
+        Anything that fails to parse as a URL is treated as a bare
+        hostname for the convenience of callers who pass either form.
         """
-        host = urlparse(path).netloc.lower()
+        parsed = urlparse(path)
+        host = parsed.hostname.lower() if parsed.hostname else ""
         if not host:
             # Caller passed a bare hostname (no scheme). Treat the whole
             # thing as the host, but still require an exact match.

--- a/src/mwlib/network/bigquery_lookup.py
+++ b/src/mwlib/network/bigquery_lookup.py
@@ -1,0 +1,133 @@
+"""BigQuery-first lookup for image description page data.
+
+Queries pre-extracted page metadata (templates, license, dimensions) from BigQuery
+instead of fetching from the remote MediaWiki API. Used for configured domains
+(default: en.wikipedia.org) where WME snapshot data is available.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mwlib.utils._conf import ConfMod
+
+logger = logging.getLogger(__name__)
+
+
+class BigQueryImageLookup:
+    """Batch lookup of image description page data from BigQuery.
+
+    Reads configuration from the [bigquery] section:
+    - project: GCP project ID (required)
+    - dataset: BigQuery dataset name
+    - table: BigQuery table name
+    - timeout: Query timeout in seconds
+    - domains: Comma-separated list of domains to handle
+    """
+
+    def __init__(self, conf: ConfMod | None = None):
+        if conf is None:
+            from mwlib.utils import conf
+
+        self.project = conf.get("bigquery", "project", "")
+        self.dataset = conf.get("bigquery", "dataset", "wme_snapshots")
+        self.table = conf.get("bigquery", "table", "file_pages")
+        self.timeout = conf.get("bigquery", "timeout", 30, int)
+
+        domains_str = conf.get("bigquery", "domains", "en.wikipedia.org")
+        self.domains = {d.strip() for d in domains_str.split(",") if d.strip()}
+
+        self._client = None
+        self._init_client()
+
+    def _init_client(self):
+        try:
+            from google.cloud import bigquery
+
+            self._client = bigquery.Client(
+                project=self.project,
+                # Use REST transport to avoid gRPC/gevent compatibility issues
+                client_options={"api_endpoint": "https://bigquery.googleapis.com"},
+            )
+        except Exception:
+            logger.warning("Failed to initialize BigQuery client", exc_info=True)
+            self._client = None
+
+    @property
+    def is_available(self) -> bool:
+        """Return True if the BigQuery client is initialized and ready."""
+        return self._client is not None
+
+    def handles_domain(self, path: str) -> bool:
+        """Check if the given URL path matches a configured BigQuery domain."""
+        return any(domain in path for domain in self.domains)
+
+    def fetch_batch(self, titles: list[str]) -> tuple[list[dict], list[str]]:
+        """Query BigQuery for image description page data.
+
+        Args:
+            titles: List of image page titles (e.g., ["File:Example.jpg", ...])
+
+        Returns:
+            Tuple of (rows, missing_titles):
+            - rows: List of dicts with BigQuery row data for found titles
+            - missing_titles: Titles not found in BigQuery (fall back to remote API)
+
+        On any error, returns ([], titles) so all titles fall back to the remote API.
+
+        """
+        if not titles or not self._client:
+            return [], list(titles)
+
+        try:
+            return self._execute_query(titles)
+        except Exception:
+            logger.warning(
+                "BigQuery lookup failed for %d titles, falling back to remote API",
+                len(titles),
+                exc_info=True,
+            )
+            return [], list(titles)
+
+    def _execute_query(self, titles: list[str]) -> tuple[list[dict], list[str]]:
+        from google.cloud import bigquery
+
+        table_ref = f"`{self.project}.{self.dataset}.{self.table}`"
+        query = f"""
+            SELECT name, identifier, url, license, templates, categories,
+                   abstract, image_content_url, image_width, image_height
+            FROM {table_ref}
+            WHERE name IN UNNEST(@titles)
+        """
+
+        job_config = bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ArrayQueryParameter("titles", "STRING", titles),
+            ],
+        )
+
+        logger.info("BigQuery query: %s", query.strip())
+        logger.info("BigQuery table: %s, titles: %r", table_ref, titles)
+
+        query_job = self._client.query(query, job_config=job_config, timeout=self.timeout)
+        results = query_job.result(timeout=self.timeout)
+
+        rows = []
+        found_titles = set()
+        for row in results:
+            row_dict = dict(row)
+            rows.append(row_dict)
+            found_titles.add(row_dict["name"])
+
+        missing = [t for t in titles if t not in found_titles]
+
+        logger.info(
+            "BigQuery lookup: %d found, %d missing out of %d requested",
+            len(rows),
+            len(missing),
+            len(titles),
+        )
+
+        return rows, missing

--- a/src/mwlib/network/bigquery_lookup.py
+++ b/src/mwlib/network/bigquery_lookup.py
@@ -8,12 +8,26 @@ instead of fetching from the remote MediaWiki API. Used for configured domains
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from mwlib.utils._conf import ConfMod
 
 logger = logging.getLogger(__name__)
+
+# BigQuery identifiers (project / dataset / table) cannot be passed as query
+# parameters — they're interpolated into the SQL string. Validate them up front
+# so a misconfigured or malicious config can't break the query or smuggle
+# arbitrary SQL through ``table_ref``.
+_BIGQUERY_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
+
+
+def _validate_bigquery_identifier(value: str, label: str) -> str:
+    if not value or not _BIGQUERY_IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"Invalid BigQuery {label}: {value!r}")
+    return value
 
 
 class BigQueryImageLookup:
@@ -61,8 +75,20 @@ class BigQueryImageLookup:
         return self._client is not None
 
     def handles_domain(self, path: str) -> bool:
-        """Check if the given URL path matches a configured BigQuery domain."""
-        return any(domain in path for domain in self.domains)
+        """Return True if the host in ``path`` is exactly one of the configured domains.
+
+        Uses hostname-exact matching, not substring containment. A naive
+        ``"en.wikipedia.org" in path`` would also match attacker-controlled
+        hosts like ``en.wikipedia.org.example.com`` or unrelated query
+        strings. Anything that fails to parse as a URL is treated as a
+        bare hostname for the convenience of callers who pass either form.
+        """
+        host = urlparse(path).netloc.lower()
+        if not host:
+            # Caller passed a bare hostname (no scheme). Treat the whole
+            # thing as the host, but still require an exact match.
+            host = path.lower().strip("/")
+        return host in self.domains
 
     def fetch_batch(self, titles: list[str]) -> tuple[list[dict], list[str]]:
         """Query BigQuery for image description page data.
@@ -94,13 +120,17 @@ class BigQueryImageLookup:
     def _execute_query(self, titles: list[str]) -> tuple[list[dict], list[str]]:
         from google.cloud import bigquery
 
-        table_ref = f"`{self.project}.{self.dataset}.{self.table}`"
+        project = _validate_bigquery_identifier(self.project, "project")
+        dataset = _validate_bigquery_identifier(self.dataset, "dataset")
+        table = _validate_bigquery_identifier(self.table, "table")
+        table_ref = f"`{project}.{dataset}.{table}`"
+
         query = f"""
             SELECT name, identifier, url, license, templates, categories,
                    abstract, image_content_url, image_width, image_height
             FROM {table_ref}
             WHERE name IN UNNEST(@titles)
-        """
+        """  # noqa: S608  identifiers validated above; titles bound as parameter
 
         job_config = bigquery.QueryJobConfig(
             query_parameters=[
@@ -108,20 +138,40 @@ class BigQueryImageLookup:
             ],
         )
 
-        logger.info("BigQuery query: %s", query.strip())
-        logger.info("BigQuery table: %s, titles: %r", table_ref, titles)
+        # Title batches contain user-controlled page/image names. Keep them
+        # at debug level so they don't end up in production info logs.
+        logger.debug("BigQuery query: %s", query.strip())
+        logger.debug("BigQuery table=%s, %d titles", table_ref, len(titles))
 
         query_job = self._client.query(query, job_config=job_config, timeout=self.timeout)
         results = query_job.result(timeout=self.timeout)
 
-        rows = []
-        found_titles = set()
+        # Only accept rows whose name is exactly one of our requested titles.
+        # A row with a normalized name (different casing, different namespace
+        # prefix, …) is discarded — leaving its requested title in ``missing``
+        # so the caller falls back to the remote API and any deferred state
+        # keyed on the original title is still reachable.
+        requested = set(titles)
+        rows: list[dict] = []
+        found_titles: set[str] = set()
+        unexpected = 0
         for row in results:
             row_dict = dict(row)
+            row_name = row_dict.get("name")
+            if row_name not in requested:
+                unexpected += 1
+                continue
             rows.append(row_dict)
-            found_titles.add(row_dict["name"])
+            found_titles.add(row_name)
 
         missing = [t for t in titles if t not in found_titles]
+
+        if unexpected:
+            logger.warning(
+                "BigQuery returned %d rows with names not in the request set; "
+                "those titles will be retried via the remote API",
+                unexpected,
+            )
 
         logger.info(
             "BigQuery lookup: %d found, %d missing out of %d requested",

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -501,6 +501,15 @@ class Fetcher:
         dispatch_gr = gevent.spawn(call_when, self.dispatch_event, self.dispatch)
         try:
             self.pool.join()
+            # Small batches that never reached ``_bq_batch_size`` are still
+            # sitting in ``_bq_pending`` here. Flushing them spawns new
+            # greenlets (image downloads + remote-API fallbacks) on
+            # ``self.pool``, so we have to join the pool a second time —
+            # otherwise ``finish()`` would close fsout while those
+            # greenlets were still writing to it.
+            if self.bq_lookup and self._bq_pending:
+                self._flush_bq_batch()
+                self.pool.join()
         finally:
             dispatch_gr.kill()
 
@@ -1103,26 +1112,13 @@ class Fetcher:
         """
         title = row["name"]
 
-        # Parse templates from BigQuery JSON column
-        raw_templates = row.get("templates") or []
-        # BigQuery JSON columns may be returned as a JSON string
-        if isinstance(raw_templates, str):
-            raw_templates = json.loads(raw_templates)
-        # Templates are objects like {"name": "Template:Cc-by-sa", "url": "..."}
-        # Extract just the template names, stripping the "Template:" prefix
-        template_names = []
-        for t in raw_templates:
-            if isinstance(t, dict):
-                name = t.get("name", "")
-                if name.startswith("Template:"):
-                    name = name[len("Template:") :]
-                template_names.append(name)
-            elif isinstance(t, str):
-                template_names.append(t)
+        template_names = self._extract_bq_template_names(title, row.get("templates"))
 
-        # Store extracted template names in templates.db
-        if template_names:
-            self.fsout.set_db_key("templates", title, template_names)
+        # Store an entry for every BigQuery hit, including the empty list,
+        # so render-time ``get_image_templates_and_args`` can rely on the
+        # cache and not silently fall back to wikitext parsing for an image
+        # we deliberately decided not to fetch.
+        self.fsout.set_db_key("templates", title, template_names)
 
         # Early license check
         passes_license = self._check_license_from_templates(template_names)
@@ -1146,6 +1142,50 @@ class Fetcher:
 
         return passes_license
 
+    @staticmethod
+    def _extract_bq_template_names(title: str, raw_templates) -> list[str]:
+        """Pull the ``Template:Name`` list out of a BigQuery row's templates column.
+
+        BigQuery returns the column either as a Python list (for native
+        REPEATED RECORD columns) or as a JSON string (for JSON columns).
+        Anything we can't parse — malformed JSON, unexpected shape — is
+        treated as "no templates" for this single row rather than raising.
+        Letting this raise would abort the whole batch flush after the
+        BigQuery query had already succeeded, bypassing the per-title
+        remote-API fallback for every other row in the batch.
+        """
+        if raw_templates is None:
+            return []
+        if isinstance(raw_templates, str):
+            try:
+                raw_templates = json.loads(raw_templates)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "BigQuery returned malformed templates JSON for %s; treating as empty",
+                    title,
+                )
+                return []
+        if not isinstance(raw_templates, list):
+            logger.warning(
+                "BigQuery templates for %s is %s, expected list; treating as empty",
+                title,
+                type(raw_templates).__name__,
+            )
+            return []
+
+        # Templates are objects like {"name": "Template:Cc-by-sa", "url": "..."}.
+        # Extract just the template names, stripping the "Template:" prefix.
+        template_names: list[str] = []
+        for t in raw_templates:
+            if isinstance(t, dict):
+                name = t.get("name", "")
+                if name.startswith("Template:"):
+                    name = name[len("Template:") :]
+                template_names.append(name)
+            elif isinstance(t, str):
+                template_names.append(t)
+        return template_names
+
     def _check_license_from_templates(self, templates: list[str]) -> bool:
         """Decide whether an image passes the license filter at fetch time.
 
@@ -1166,13 +1206,18 @@ class Fetcher:
     def get_image_edits(self, title: str, api: MwApi):
         """Get edit history for an image page.
 
-        This method is now a wrapper around _add_to_authors_batch, which collects titles
-        for batched processing. The actual API request is made when the batch is full
-        or when explicitly flushed.
+        Adds ``title`` to the contributor-lookup batch (currently a
+        single-title path that runs the API request immediately).
+
+        Order matters: ``title_mapping`` must be populated **before**
+        ``_add_to_titles_pending_contributor_lookup`` so that
+        ``_lookup_contributors`` sees the local-namespace mapping and
+        writes ``authors`` under the local title instead of the remote
+        one.
 
         Args:
-            title (str): Title of the image page to get edit history for
-            api (MwApi): API instance to use for the request
+            title: Title of the image page to get edit history for.
+            api: API instance to use for the request.
 
         """
         local_nsname = self.nshandler.get_nsname_by_number(6)
@@ -1180,11 +1225,11 @@ class Fetcher:
         _, partial = title.split(":", 1)
         local_title = f"{local_nsname}:{partial}"
 
-        # Add the title to the batch
-        self._add_to_titles_pending_contributor_lookup(title, api)
-
-        # Map the original title to the local title for later use
+        # Map the original title to the local title FIRST, before the
+        # (immediate) contributor lookup runs.
         self.title_mapping[title] = local_title
+
+        self._add_to_titles_pending_contributor_lookup(title, api)
 
     def _get_mwapi_for_path(self, path):
         urls = mwapi.guess_api_urls(path)
@@ -1256,9 +1301,8 @@ class Fetcher:
 
     def finish(self):
         self._sanity_check()
-        # Flush any remaining BigQuery batch
-        if self.bq_lookup and self._bq_pending:
-            self._flush_bq_batch()
+        # NB: BigQuery batch flushing has already happened in ``run()`` —
+        # it spawns greenlets and so must run before the final pool.join().
         # Process any pending authors batch
         self.lookup_contributors_for_remaining_titles()
         for api in self.titles_pending_contributor_lookup:

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -1063,8 +1063,11 @@ class Fetcher:
             if len(self._bq_pending) >= self._bq_batch_size:
                 self._flush_bq_batch()
             # Contributor lookup needs the remote API. If api creation
-            # failed above we accept the loss of contributor metadata
-            # rather than dropping the BigQuery hit on the floor.
+            # failed above we don't schedule it; ``_flush_bq_batch`` then
+            # fails closed for those entries (drops the deferred image
+            # download regardless of whether BigQuery had a hit), so the
+            # rendered book never includes an image with license data
+            # but no attribution.
             if api is not None:
                 for local_name, _ in local_names:
                     self._refcall(self.get_image_edits, local_name, api)

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -1111,6 +1111,13 @@ class Fetcher:
         # remote-API fallback applies the description-page parser
         # instead — silently treating corrupt template data as "no
         # templates" would fail open in blacklist mode.
+        #
+        # Entries with ``api=None`` are also fail-closed: BigQuery has
+        # the license/template data, but ``handle_new_basepath``
+        # skipped ``get_image_edits`` because remote-API discovery
+        # failed. Downloading the image would produce a rendered book
+        # with no contributor attribution, so we drop the deferred
+        # download even on a clean BigQuery hit.
         for row in rows:
             local_name = row["name"]
             orig_title = orig_by_local.get(local_name, local_name)
@@ -1120,6 +1127,18 @@ class Fetcher:
                 logger.warning("Routing %s to remote-API fallback: %s", local_name, exc)
                 missing.append(local_name)
                 continue
+
+            if api_by_local.get(local_name) is None:
+                if orig_title in self._bq_deferred_downloads:
+                    self._bq_deferred_downloads.pop(orig_title, None)
+                    logger.warning(
+                        "Skipping image download for %s: BigQuery has the row "
+                        "but contributor lookup was not scheduled (no remote "
+                        "API available) — refusing to ship an unattributed image",
+                        orig_title,
+                    )
+                continue
+
             if passes_license and orig_title in self._bq_deferred_downloads:
                 self.schedule_download_image(
                     self._bq_deferred_downloads.pop(orig_title), orig_title

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -299,7 +299,9 @@ def _acquire_download_rate_limit(url):
             limiter = mwapi.RateLimiter(max_calls=max_rps, period=1.0)
             _download_rate_limiter[origin] = limiter
             _download_rate_limiter_rps[origin] = max_rps
-            logger.info(f"Download rate limiter initialized for {origin}: {max_rps} requests/second")
+            logger.info(
+                f"Download rate limiter initialized for {origin}: {max_rps} requests/second"
+            )
 
     limiter.acquire()
 
@@ -314,9 +316,6 @@ def download_to_file(url, path, temp_path, max_retries=0, initial_delay=1, backo
 
 
 class Fetcher:
-    titles_pending_contributor_lookup = defaultdict(list)
-    title_mapping = {}
-
     def __init__(
         self,
         api,
@@ -331,6 +330,13 @@ class Fetcher:
     ):
         self.dispatch_event = gevent.event.Event()
         self.api_semaphore = Semaphore(conf.get("fetch", "api_request_limit", 5, int))
+
+        # Per-instance state. Previously these were class-level defaults
+        # (``defaultdict(list)`` and ``{}``), which leaked across Fetcher
+        # instances in the same process — concurrent or sequential fetches
+        # could see each other's titles and mappings.
+        self.titles_pending_contributor_lookup = defaultdict(list)
+        self.title_mapping = {}
 
         self.cover_image = cover_image
 
@@ -768,45 +774,40 @@ class Fetcher:
         # Reverting to looking up individual titles - at least for the time being
         self._lookup_contributors(api, title)
 
-    def _lookup_contributors(self, api: MwApi, title=None) -> None:
-        """Process the current batch of titles for author information.
+    def _lookup_contributors(self, api: MwApi, title: str | None = None) -> None:
+        """Look up authors for one title, or for the entire pending batch.
 
-        This method makes a single API request for all titles in the batch,
-        then processes the results and stores them in the database.
+        When ``title`` is given, only that title is looked up — the pending
+        batch is left untouched. When ``title`` is None, the pending batch
+        for ``api`` is consumed and cleared.
+
+        The previous version took ``title`` but iterated
+        ``titles_pending_contributor_lookup[api]`` regardless, which —
+        combined with `_add_to_titles_pending_contributor_lookup` no longer
+        appending to the batch in the single-title path — silently dropped
+        author attribution for every page.
         """
-        # Make the API request for all titles in the batch
-        if title is None:
-            title_to_authors = api.get_contributors(self.titles_pending_contributor_lookup[api])
+        if title is not None:
+            titles = [title]
         else:
-            title_to_authors = api.get_contributors([title])
+            titles = list(self.titles_pending_contributor_lookup[api])
 
-        # Process the results for each title
-        authors_dict = {}
-        title: str
-        for title in self.titles_pending_contributor_lookup[api]:
-            # Skip if the title is not in the results (e.g., if it was redirected)
-            if title not in title_to_authors:
+        if not titles:
+            return
+
+        title_to_authors = api.get_contributors(titles)
+
+        for contributor_title in titles:
+            inspect_authors = title_to_authors.get(contributor_title)
+            if inspect_authors is None:
+                # Skipped, e.g. redirected away — nothing to record.
                 continue
-
-            # Get the InspectAuthors object for this title
-            inspect_authors = title_to_authors[title]
-
-            # Get the authors for this title
             authors = inspect_authors.get_authors()
-
-            # Use the mapped title if available (for image pages)
-            db_title = title
-            if title in self.title_mapping:
-                db_title = self.title_mapping[title]
-
-            # Store the authors in the database
+            db_title = self.title_mapping.get(contributor_title, contributor_title)
             self.fsout.set_db_key("authors", db_title, authors)
 
-            # Store the authors in a dictionary for future use
-            authors_dict[title] = authors
-
-        # Clear the batch
-        self.authors_batch = []
+        if title is None:
+            self.titles_pending_contributor_lookup[api] = []
 
     def report(self):
         query_count = self.api.qccount
@@ -1070,7 +1071,9 @@ class Fetcher:
             orig_title = orig_by_local.get(local_name, local_name)
             passes_license = self._store_bq_result(row)
             if passes_license and orig_title in self._bq_deferred_downloads:
-                self.schedule_download_image(self._bq_deferred_downloads.pop(orig_title), orig_title)
+                self.schedule_download_image(
+                    self._bq_deferred_downloads.pop(orig_title), orig_title
+                )
             elif not passes_license:
                 self._bq_deferred_downloads.pop(orig_title, None)
                 logger.info("Skipping image download for %s (license filtered)", orig_title)
@@ -1112,7 +1115,7 @@ class Fetcher:
             if isinstance(t, dict):
                 name = t.get("name", "")
                 if name.startswith("Template:"):
-                    name = name[len("Template:"):]
+                    name = name[len("Template:") :]
                 template_names.append(name)
             elif isinstance(t, str):
                 template_names.append(t)
@@ -1122,7 +1125,7 @@ class Fetcher:
             self.fsout.set_db_key("templates", title, template_names)
 
         # Early license check
-        passes_license = self._check_license_from_templates(title, template_names)
+        passes_license = self._check_license_from_templates(template_names)
 
         # Supplement imageinfo with dimensions and content URL
         existing = {}
@@ -1143,23 +1146,22 @@ class Fetcher:
 
         return passes_license
 
-    def _check_license_from_templates(self, title: str, templates: list[str]) -> bool:
-        """Check if image should be included based on templates.
+    def _check_license_from_templates(self, templates: list[str]) -> bool:
+        """Decide whether an image passes the license filter at fetch time.
 
-        Returns True if the image passes the license filter.
+        Delegates the actual policy to ``LicenseChecker.license_passes_filter``
+        so this stays bit-for-bit aligned with render-time
+        ``LicenseChecker._check_licenses`` even as policy evolves. Without a
+        configured ``fetch_license_checker`` everything is included
+        unfiltered (legacy behaviour preserved).
         """
         if not self.fetch_license_checker:
-            return True  # no checker → include everything
+            return True
         lowered = [t.lower() for t in templates]
         licenses = self.fetch_license_checker._get_licenses(lowered)
-        # Simplified check: no stats tracking (no image_db needed)
-        for lic in licenses:
-            if lic.license_type == "free":
-                return True
-            elif lic.license_type == "nonfree":
-                return self.fetch_license_checker.filter_type == "nofilter"
-        # All unknown → follow filter_type
-        return self.fetch_license_checker.filter_type in ["blacklist", "nofilter"]
+        return self.fetch_license_checker.license_passes_filter(
+            licenses, self.fetch_license_checker.filter_type
+        )
 
     def get_image_edits(self, title: str, api: MwApi):
         """Get edit history for an image page.

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -111,7 +111,7 @@ class FsOutput:
         self.imgcount = 0
         self.nfo = None
 
-        for storage in ["authors", "html", "imageinfo"]:
+        for storage in ["authors", "html", "imageinfo", "templates"]:
             db_path = os.path.join(self.path, storage + ".db")
             if os.path.exists(db_path):
                 os.remove(db_path)
@@ -371,6 +371,28 @@ class Fetcher:
         self.imageinfo_todo = []
         self.imagedescription_todo = {}  # base path -> list
         self._nshandler = None
+
+        # BigQuery lookup for image description pages
+        self.bq_lookup = None
+        self._bq_pending = []  # (local_name, api, original_title) tuples awaiting BQ lookup
+        self._bq_batch_size = 50  # flush threshold
+        self._bq_deferred_downloads = {}  # original_title → thumburl, awaiting license check
+        self.fetch_license_checker = None
+        if conf.get("bigquery", "enabled", False, bool):
+            try:
+                from mwlib.network.bigquery_lookup import BigQueryImageLookup
+
+                self.bq_lookup = BigQueryImageLookup()
+            except Exception:
+                logger.warning("BigQuery lookup init failed, using remote API", exc_info=True)
+
+        if self.bq_lookup and self.bq_lookup.is_available:
+            from mwlib.rendering.licensechecker import LicenseChecker
+
+            # Match render-time policy: de.wikipedia.org uses whitelist, others blacklist
+            filter_type = "whitelist" if "de.wikipedia.org" in self.api.apiurl else "blacklist"
+            self.fetch_license_checker = LicenseChecker(image_db=None, filter_type=filter_type)
+            self.fetch_license_checker.read_licenses_csv()
 
         siteinfo = self.get_siteinfo_for(self.api)
         self.fsout.write_siteinfo(siteinfo)
@@ -917,11 +939,21 @@ class Fetcher:
             # FIXME: add Callback that checks correct file size
             if thumb_url.startswith("/"):
                 thumb_url = parse.urljoin(self.api.baseurl, thumb_url)
-            self.schedule_download_image(thumb_url, title)
 
             description_url = imageinfo.get("descriptionurl", "")
             if not description_url:
                 description_url = image.get("fullurl", "")
+
+            # Defer download for BigQuery-eligible domains (license check first)
+            if (
+                self.bq_lookup
+                and self.bq_lookup.is_available
+                and description_url
+                and self.bq_lookup.handles_domain(description_url)
+            ):
+                self._bq_deferred_downloads[title] = thumb_url
+            else:
+                self.schedule_download_image(thumb_url, title)
 
             if description_url and "/" in description_url:
                 path, _ = description_url.rsplit("/", 1)
@@ -983,13 +1015,151 @@ class Fetcher:
         local_names = []
         for title in titles:
             partial = title.split(":", 1)[1]
-            local_names.append(f"{nsname}:{partial}")
+            local_names.append((f"{nsname}:{partial}", title))
 
-        for block in split_blocks(local_names, api.api_request_limit):
+        # BigQuery-eligible: collect into pending batch
+        if self.bq_lookup and self.bq_lookup.is_available and self.bq_lookup.handles_domain(path):
+            for local_name, orig_title in local_names:
+                self._bq_pending.append((local_name, api, orig_title))
+            if len(self._bq_pending) >= self._bq_batch_size:
+                self._flush_bq_batch()
+            # Contributor lookup always uses remote API
+            for local_name, _ in local_names:
+                self._refcall(self.get_image_edits, local_name, api)
+            return
+
+        # Non-BigQuery path: unchanged
+        just_names = [ln for ln, _ in local_names]
+        for block in split_blocks(just_names, api.api_request_limit):
             self._refcall(self.fetch_image_page, block, api)
 
-        for title in local_names:
-            self._refcall(self.get_image_edits, title, api)
+        for local_name, _ in local_names:
+            self._refcall(self.get_image_edits, local_name, api)
+
+    def _flush_bq_batch(self):
+        """Send all pending titles to BigQuery in a single query.
+
+        Titles found in BigQuery are stored locally. Missing titles fall back
+        to the remote API. Deferred image downloads are scheduled or skipped
+        based on the license check result.
+        """
+        if not self._bq_pending:
+            return
+
+        pending = self._bq_pending
+        self._bq_pending = []
+
+        # Build mappings: local_name → api, local_name → original_title
+        # Deduplicate titles for the BigQuery query
+        api_by_local = {}
+        orig_by_local = {}
+        seen = set()
+        unique_titles = []
+        for local_name, api, orig_title in pending:
+            api_by_local[local_name] = api
+            orig_by_local[local_name] = orig_title
+            if local_name not in seen:
+                seen.add(local_name)
+                unique_titles.append(local_name)
+
+        rows, missing = self.bq_lookup.fetch_batch(unique_titles)
+
+        # Store BigQuery results + license check + deferred downloads
+        for row in rows:
+            local_name = row["name"]
+            orig_title = orig_by_local.get(local_name, local_name)
+            passes_license = self._store_bq_result(row)
+            if passes_license and orig_title in self._bq_deferred_downloads:
+                self.schedule_download_image(self._bq_deferred_downloads.pop(orig_title), orig_title)
+            elif not passes_license:
+                self._bq_deferred_downloads.pop(orig_title, None)
+                logger.info("Skipping image download for %s (license filtered)", orig_title)
+
+        # Fall back to remote API for missing titles
+        if missing:
+            by_api = {}
+            for local_name in missing:
+                api = api_by_local.get(local_name)
+                if api:
+                    by_api.setdefault(api, []).append(local_name)
+            for api, api_titles in by_api.items():
+                for block in split_blocks(api_titles, api.api_request_limit):
+                    self._refcall(self.fetch_image_page, block, api)
+            # Schedule deferred downloads for fallback titles (no license info yet)
+            for local_name in missing:
+                orig_title = orig_by_local.get(local_name, local_name)
+                if orig_title in self._bq_deferred_downloads:
+                    self.schedule_download_image(
+                        self._bq_deferred_downloads.pop(orig_title), orig_title
+                    )
+
+    def _store_bq_result(self, row) -> bool:
+        """Store a BigQuery row into fsout databases.
+
+        Returns True if the image passes the license check.
+        """
+        title = row["name"]
+
+        # Parse templates from BigQuery JSON column
+        raw_templates = row.get("templates") or []
+        # BigQuery JSON columns may be returned as a JSON string
+        if isinstance(raw_templates, str):
+            raw_templates = json.loads(raw_templates)
+        # Templates are objects like {"name": "Template:Cc-by-sa", "url": "..."}
+        # Extract just the template names, stripping the "Template:" prefix
+        template_names = []
+        for t in raw_templates:
+            if isinstance(t, dict):
+                name = t.get("name", "")
+                if name.startswith("Template:"):
+                    name = name[len("Template:"):]
+                template_names.append(name)
+            elif isinstance(t, str):
+                template_names.append(t)
+
+        # Store extracted template names in templates.db
+        if template_names:
+            self.fsout.set_db_key("templates", title, template_names)
+
+        # Early license check
+        passes_license = self._check_license_from_templates(title, template_names)
+
+        # Supplement imageinfo with dimensions and content URL
+        existing = {}
+        with contextlib.suppress(KeyError, ValueError):
+            existing = self.fsout.get_db_key("imageinfo", title)
+
+        if row.get("image_content_url"):
+            existing.setdefault("url", row["image_content_url"])
+        if row.get("image_width"):
+            existing.setdefault("width", row["image_width"])
+        if row.get("image_height"):
+            existing.setdefault("height", row["image_height"])
+        if row.get("url"):
+            existing.setdefault("descriptionurl", row["url"])
+
+        if existing:
+            self.fsout.set_db_key("imageinfo", title, existing)
+
+        return passes_license
+
+    def _check_license_from_templates(self, title: str, templates: list[str]) -> bool:
+        """Check if image should be included based on templates.
+
+        Returns True if the image passes the license filter.
+        """
+        if not self.fetch_license_checker:
+            return True  # no checker → include everything
+        lowered = [t.lower() for t in templates]
+        licenses = self.fetch_license_checker._get_licenses(lowered)
+        # Simplified check: no stats tracking (no image_db needed)
+        for lic in licenses:
+            if lic.license_type == "free":
+                return True
+            elif lic.license_type == "nonfree":
+                return self.fetch_license_checker.filter_type == "nofilter"
+        # All unknown → follow filter_type
+        return self.fetch_license_checker.filter_type in ["blacklist", "nofilter"]
 
     def get_image_edits(self, title: str, api: MwApi):
         """Get edit history for an image page.
@@ -1084,6 +1254,9 @@ class Fetcher:
 
     def finish(self):
         self._sanity_check()
+        # Flush any remaining BigQuery batch
+        if self.bq_lookup and self._bq_pending:
+            self._flush_bq_batch()
         # Process any pending authors batch
         self.lookup_contributors_for_remaining_titles()
         for api in self.titles_pending_contributor_lookup:

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -42,6 +42,16 @@ _download_rate_limiter_rps = {}
 _download_rate_limiter_init_lock = Semaphore(1)
 
 
+class BqTemplatesError(ValueError):
+    """A BigQuery row's ``templates`` field couldn't be parsed.
+
+    The flush loop catches this and reroutes the title to the remote-API
+    fallback rather than persisting a row whose license-check input is
+    unknown — an empty template list passes ``blacklist`` mode, so
+    silently treating corrupt data as empty would fail open.
+    """
+
+
 class SharedProgress:
     status = None
     last_percent = 0.0
@@ -1005,7 +1015,6 @@ class Fetcher:
         self.fsout.write_pages(data)
 
     def handle_new_basepath(self, path):
-        api = self._get_mwapi_for_path(path)
         todo = self.imagedescription_todo[path]
         del self.imagedescription_todo[path]
 
@@ -1017,25 +1026,47 @@ class Fetcher:
         if not titles:
             return
 
-        siteinfo = self.get_siteinfo_for(api)
+        bq_eligible = (
+            self.bq_lookup and self.bq_lookup.is_available and self.bq_lookup.handles_domain(path)
+        )
 
-        ns_handler = nshandling.NsHandler(siteinfo)
-        nsname = ns_handler.get_nsname_by_number(6)
+        # Build the api / siteinfo lazily so a flaky remote can't kill a
+        # working BigQuery cache hit. If BQ would handle this path we can
+        # fall back to the EN nshandler — BigQuery snapshots are EN-keyed
+        # ("File:...") so that's the canonical name shape we need for the
+        # lookup.
+        api = None
+        nsname = None
+        try:
+            api = self._get_mwapi_for_path(path)
+            siteinfo = self.get_siteinfo_for(api)
+            nsname = nshandling.NsHandler(siteinfo).get_nsname_by_number(6)
+        except Exception:
+            if not bq_eligible:
+                raise
+            logger.warning(
+                "Remote siteinfo failed for %s; proceeding via BigQuery only",
+                path,
+                exc_info=True,
+            )
+            nsname = nshandling.get_nshandler_for_lang("en").get_nsname_by_number(6)
 
         local_names = []
         for title in titles:
             partial = title.split(":", 1)[1]
             local_names.append((f"{nsname}:{partial}", title))
 
-        # BigQuery-eligible: collect into pending batch
-        if self.bq_lookup and self.bq_lookup.is_available and self.bq_lookup.handles_domain(path):
+        if bq_eligible:
             for local_name, orig_title in local_names:
                 self._bq_pending.append((local_name, api, orig_title))
             if len(self._bq_pending) >= self._bq_batch_size:
                 self._flush_bq_batch()
-            # Contributor lookup always uses remote API
-            for local_name, _ in local_names:
-                self._refcall(self.get_image_edits, local_name, api)
+            # Contributor lookup needs the remote API. If api creation
+            # failed above we accept the loss of contributor metadata
+            # rather than dropping the BigQuery hit on the floor.
+            if api is not None:
+                for local_name, _ in local_names:
+                    self._refcall(self.get_image_edits, local_name, api)
             return
 
         # Non-BigQuery path: unchanged
@@ -1074,11 +1105,20 @@ class Fetcher:
 
         rows, missing = self.bq_lookup.fetch_batch(unique_titles)
 
-        # Store BigQuery results + license check + deferred downloads
+        # Store BigQuery results + license check + deferred downloads.
+        # Rows with unparseable templates go onto ``missing`` so the
+        # remote-API fallback applies the description-page parser
+        # instead — silently treating corrupt template data as "no
+        # templates" would fail open in blacklist mode.
         for row in rows:
             local_name = row["name"]
             orig_title = orig_by_local.get(local_name, local_name)
-            passes_license = self._store_bq_result(row)
+            try:
+                passes_license = self._store_bq_result(row)
+            except BqTemplatesError as exc:
+                logger.warning("Routing %s to remote-API fallback: %s", local_name, exc)
+                missing.append(local_name)
+                continue
             if passes_license and orig_title in self._bq_deferred_downloads:
                 self.schedule_download_image(
                     self._bq_deferred_downloads.pop(orig_title), orig_title
@@ -1148,30 +1188,28 @@ class Fetcher:
 
         BigQuery returns the column either as a Python list (for native
         REPEATED RECORD columns) or as a JSON string (for JSON columns).
-        Anything we can't parse — malformed JSON, unexpected shape — is
-        treated as "no templates" for this single row rather than raising.
-        Letting this raise would abort the whole batch flush after the
-        BigQuery query had already succeeded, bypassing the per-title
-        remote-API fallback for every other row in the batch.
+        ``None`` and ``[]`` are legitimate "no templates" signals and
+        return ``[]``.
+
+        Anything we can't parse (malformed JSON, unexpected shape) raises
+        ``BqTemplatesError``. The flush loop catches that and reroutes
+        the title to the remote-API fallback rather than treating it as
+        empty — an empty template list passes ``blacklist`` mode, so
+        silently treating corrupt data as empty would fail open and let
+        through images the remote description-page parser may have
+        rejected.
         """
         if raw_templates is None:
             return []
         if isinstance(raw_templates, str):
             try:
                 raw_templates = json.loads(raw_templates)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "BigQuery returned malformed templates JSON for %s; treating as empty",
-                    title,
-                )
-                return []
+            except (ValueError, TypeError) as exc:
+                raise BqTemplatesError(f"malformed templates JSON for {title}") from exc
         if not isinstance(raw_templates, list):
-            logger.warning(
-                "BigQuery templates for %s is %s, expected list; treating as empty",
-                title,
-                type(raw_templates).__name__,
+            raise BqTemplatesError(
+                f"templates for {title} is {type(raw_templates).__name__}, expected list"
             )
-            return []
 
         # Templates are objects like {"name": "Template:Cc-by-sa", "url": "..."}.
         # Extract just the template names, stripping the "Template:" prefix.

--- a/src/mwlib/network/fetch.py
+++ b/src/mwlib/network/fetch.py
@@ -405,9 +405,10 @@ class Fetcher:
         if self.bq_lookup and self.bq_lookup.is_available:
             from mwlib.rendering.licensechecker import LicenseChecker
 
-            # Match render-time policy: de.wikipedia.org uses whitelist, others blacklist
-            filter_type = "whitelist" if "de.wikipedia.org" in self.api.apiurl else "blacklist"
-            self.fetch_license_checker = LicenseChecker(image_db=None, filter_type=filter_type)
+            self.fetch_license_checker = LicenseChecker(
+                image_db=None,
+                filter_type=self._filter_type_for_apiurl(self.api.apiurl),
+            )
             self.fetch_license_checker.read_licenses_csv()
 
         siteinfo = self.get_siteinfo_for(self.api)
@@ -1127,23 +1128,45 @@ class Fetcher:
                 self._bq_deferred_downloads.pop(orig_title, None)
                 logger.info("Skipping image download for %s (license filtered)", orig_title)
 
-        # Fall back to remote API for missing titles
+        # Fall back to remote API for missing titles. Some entries may
+        # have ``api=None`` because ``handle_new_basepath`` proceeded
+        # via BigQuery after a remote-discovery failure — for those we
+        # have no way to fetch the description page, so we must NOT
+        # schedule the deferred image download either. Otherwise we'd
+        # ship an image with no license/attribution data at all.
         if missing:
             by_api = {}
+            without_api = []
             for local_name in missing:
                 api = api_by_local.get(local_name)
-                if api:
+                if api is None:
+                    without_api.append(local_name)
+                else:
                     by_api.setdefault(api, []).append(local_name)
+
             for api, api_titles in by_api.items():
                 for block in split_blocks(api_titles, api.api_request_limit):
                     self._refcall(self.fetch_image_page, block, api)
-            # Schedule deferred downloads for fallback titles (no license info yet)
-            for local_name in missing:
+
+            # Deferred downloads only for titles that DID get a fallback
+            # description-page fetch scheduled.
+            fallback_titles = {t for ts in by_api.values() for t in ts}
+            for local_name in fallback_titles:
                 orig_title = orig_by_local.get(local_name, local_name)
                 if orig_title in self._bq_deferred_downloads:
                     self.schedule_download_image(
                         self._bq_deferred_downloads.pop(orig_title), orig_title
                     )
+
+            for local_name in without_api:
+                orig_title = orig_by_local.get(local_name, local_name)
+                self._bq_deferred_downloads.pop(orig_title, None)
+                logger.warning(
+                    "Skipping %s: BigQuery missed/failed and no remote API "
+                    "fallback is available — refusing to download an image "
+                    "without license/attribution data",
+                    orig_title,
+                )
 
     def _store_bq_result(self, row) -> bool:
         """Store a BigQuery row into fsout databases.
@@ -1213,33 +1236,52 @@ class Fetcher:
 
         # Templates are objects like {"name": "Template:Cc-by-sa", "url": "..."}.
         # Extract just the template names, stripping the "Template:" prefix.
+        # Anything that doesn't look like a real template name (missing
+        # ``name``, empty string, unexpected element type) raises rather
+        # than silently dropping into ``""`` — partial template lists
+        # can pass blacklist mode and we don't want corrupt rows to get
+        # there.
         template_names: list[str] = []
         for t in raw_templates:
             if isinstance(t, dict):
-                name = t.get("name", "")
+                name = t.get("name")
+                if not isinstance(name, str) or not name:
+                    raise BqTemplatesError(f"template entry for {title} has no valid name")
                 if name.startswith("Template:"):
                     name = name[len("Template:") :]
                 template_names.append(name)
-            elif isinstance(t, str):
+                continue
+            if isinstance(t, str) and t:
                 template_names.append(t)
+                continue
+            raise BqTemplatesError(
+                f"template entry for {title} is {type(t).__name__}, expected dict or non-empty str"
+            )
         return template_names
+
+    @staticmethod
+    def _filter_type_for_apiurl(apiurl: str) -> str:
+        """Match render-time license policy for the wiki at ``apiurl``.
+
+        de.wikipedia.org runs the whitelist; everywhere else uses the
+        blacklist. The hostname is parsed and compared exactly so a
+        lookalike URL (e.g. ``de.wikipedia.org.evil.example``) can't
+        shift policy by being a substring of ``apiurl``.
+        """
+        host = (parse.urlparse(apiurl).hostname or "").lower()
+        return "whitelist" if host == "de.wikipedia.org" else "blacklist"
 
     def _check_license_from_templates(self, templates: list[str]) -> bool:
         """Decide whether an image passes the license filter at fetch time.
 
-        Delegates the actual policy to ``LicenseChecker.license_passes_filter``
-        so this stays bit-for-bit aligned with render-time
-        ``LicenseChecker._check_licenses`` even as policy evolves. Without a
-        configured ``fetch_license_checker`` everything is included
-        unfiltered (legacy behaviour preserved).
+        Delegates to ``LicenseChecker.decide_from_template_names`` so the
+        decision stays bit-for-bit aligned with render-time
+        ``LicenseChecker._check_licenses`` and we don't have to reach into
+        ``_get_licenses`` from outside the class.
         """
         if not self.fetch_license_checker:
             return True
-        lowered = [t.lower() for t in templates]
-        licenses = self.fetch_license_checker._get_licenses(lowered)
-        return self.fetch_license_checker.license_passes_filter(
-            licenses, self.fetch_license_checker.filter_type
-        )
+        return self.fetch_license_checker.decide_from_template_names(templates)
 
     def get_image_edits(self, title: str, api: MwApi):
         """Get edit history for an image page.

--- a/src/mwlib/network/http_client.py
+++ b/src/mwlib/network/http_client.py
@@ -6,6 +6,7 @@ This module provides a singleton HTTP client manager that handles:
 3. HTTP/2 support detection and usage
 """
 
+import hashlib
 import logging
 import threading
 import time
@@ -19,6 +20,25 @@ from httpx import Client as StandardClient
 from mwlib.utils import conf
 
 logger = logging.getLogger(__name__)
+
+
+def _oauth2_cache_identity() -> str:
+    """Return a fingerprint of the current OAuth2 config for cache keying.
+
+    Two callers asking for OAuth2 against the same origin but with
+    different ``client_id`` / ``client_secret`` / ``token_url`` must NOT
+    share a cached client — otherwise a credential rotation (or a
+    multi-tenant test suite that swaps configs) silently keeps using the
+    old client. The secret is hashed so it never lands in logs or cache
+    keys in plaintext.
+    """
+    client_id = conf.get("oauth2", "client_id", "")
+    client_secret = conf.get("oauth2", "client_secret", "")
+    token_url = conf.get(
+        "oauth2", "token_url", "https://meta.wikimedia.org/w/rest.php/oauth2/access_token"
+    )
+    secret_hash = hashlib.sha256(client_secret.encode("utf-8")).hexdigest()[:16]
+    return f"client_id={client_id}|token_url={token_url}|secret={secret_hash}"
 
 
 class HttpClientManager:
@@ -37,6 +57,7 @@ class HttpClientManager:
     # the same cache key. gevent's Semaphore would also work; threading.Lock
     # is monkey-patched under gevent and is correct under both runtimes.
     _client_lock = threading.Lock()
+    _instance_lock = threading.Lock()
     # HTTP/2 probe is a real network HEAD request — keep it short so it
     # doesn't dominate startup latency on slow networks. The result is
     # cached for ``_http2_cache_ttl_seconds`` so this only matters once
@@ -45,23 +66,34 @@ class HttpClientManager:
 
     @classmethod
     def get_instance(cls) -> "HttpClientManager":
-        """Get the singleton instance of HttpClientManager.
-
-        Returns:
-            HttpClientManager: The singleton instance.
-
-        """
+        """Get the singleton instance of HttpClientManager."""
+        # Double-checked locking: avoid the lock on the hot path, take it
+        # only when the instance might genuinely need to be created.
         if cls._instance is None:
-            cls._instance = cls()
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
         return cls._instance
 
     def _origin(self, url: str) -> str:
         p = urlparse(url)
         return f"{p.scheme}://{p.netloc}"
 
+    @staticmethod
+    def _cache_key(origin: str, *, use_oauth2: bool, use_http2: bool) -> str:
+        """Build the cache key used by both ``get_client`` and ``invalidate_client``.
+
+        For OAuth2 clients the key includes a fingerprint of the
+        currently-configured credentials so that rotations create a fresh
+        client rather than reusing a stale-credential one. The secret is
+        hashed before being interpolated.
+        """
+        auth_identity = _oauth2_cache_identity() if use_oauth2 else "standard"
+        return f"{origin}|oauth2={use_oauth2}|http2={use_http2}|auth={auth_identity}"
+
     def invalidate_client(self, base_url: str, *, use_oauth2: bool, use_http2: bool) -> None:
         origin = self._origin(base_url)
-        cache_key = f"{origin}|oauth2={use_oauth2}|http2={use_http2}"
+        cache_key = self._cache_key(origin, use_oauth2=use_oauth2, use_http2=use_http2)
         client = self._clients.pop(cache_key, None)
         if client is not None:
             try:
@@ -112,9 +144,12 @@ class HttpClientManager:
         if use_http2 is None:
             use_http2 = conf.get("http2", "enabled", True, bool)
 
-        # Auto-detect HTTP/2 support if configured
+        # Auto-detect HTTP/2 support if configured. Probe the origin
+        # rather than the full ``api.php?...`` URL — heavy routes can
+        # take significantly longer to HEAD, and the result is cached
+        # per-origin anyway so the probe only hits one endpoint.
         if use_http2 and conf.get("http2", "auto_detect", True, bool):
-            use_http2 = self.detect_http2_support(base_url)
+            use_http2 = self.detect_http2_support(self._origin(base_url))
 
         origin = self._origin(base_url)
 
@@ -124,8 +159,10 @@ class HttpClientManager:
 
         headers["User-Agent"] = getattr(conf, "user_agent", "mwlib")
 
-        # Create a cache key that includes the base URL, authentication and HTTP/2 settings
-        cache_key = f"{origin}|oauth2={use_oauth2}|http2={use_http2}"
+        # Cache key includes the base URL, the auth choice, the HTTP/2
+        # decision, and (for OAuth2) a fingerprint of the credentials so
+        # rotations don't reuse a stale-cred client.
+        cache_key = self._cache_key(origin, use_oauth2=use_oauth2, use_http2=use_http2)
 
         # Fast path: cache hit. Don't take the lock if we don't have to.
         if cache_key in self._clients:

--- a/src/mwlib/network/http_client.py
+++ b/src/mwlib/network/http_client.py
@@ -7,13 +7,14 @@ This module provides a singleton HTTP client manager that handles:
 """
 
 import logging
+import threading
 import time
-from typing import Dict, Optional, Union, Any
+from typing import Dict, Optional, Union
 from urllib.parse import urlparse
 
 import httpx
-from httpx import Client as StandardClient
 from authlib.integrations.httpx_client import OAuth2Client
+from httpx import Client as StandardClient
 
 from mwlib.utils import conf
 
@@ -32,6 +33,15 @@ class HttpClientManager:
     _clients: Dict[str, Union[StandardClient, OAuth2Client]] = {}
     _http2_support_cache: Dict[str, Dict[str, float | bool]] = {}
     _http2_cache_ttl_seconds = 300
+    # Guard against two greenlets/threads creating duplicate clients for
+    # the same cache key. gevent's Semaphore would also work; threading.Lock
+    # is monkey-patched under gevent and is correct under both runtimes.
+    _client_lock = threading.Lock()
+    # HTTP/2 probe is a real network HEAD request — keep it short so it
+    # doesn't dominate startup latency on slow networks. The result is
+    # cached for ``_http2_cache_ttl_seconds`` so this only matters once
+    # per origin.
+    _http2_probe_timeout_seconds = 2.0
 
     @classmethod
     def get_instance(cls) -> "HttpClientManager":
@@ -39,6 +49,7 @@ class HttpClientManager:
 
         Returns:
             HttpClientManager: The singleton instance.
+
         """
         if cls._instance is None:
             cls._instance = cls()
@@ -74,10 +85,29 @@ class HttpClientManager:
 
         Returns:
             Union[httpx.Client, OAuth2Client]: The HTTP client.
+
         """
         # Determine whether to use OAuth2 and HTTP/2 from configuration if not specified
         if use_oauth2 is None:
             use_oauth2 = conf.get("oauth2", "enabled", False, bool)
+
+        # Resolve OAuth2 *before* building the cache key. Falling back from
+        # OAuth2 to standard inside ``create_oauth2_client`` would otherwise
+        # leave a standard client cached under ``oauth2=True`` — and a
+        # later caller asking for OAuth2 would get that standard client
+        # back, while ``MwApi.use_oauth2`` stayed True and tried to call
+        # ``fetch_token`` on a non-OAuth2 client. By deciding here, both
+        # the cache key and the eventual ``isinstance`` check on the
+        # returned client agree.
+        if use_oauth2:
+            client_id = conf.get("oauth2", "client_id", "")
+            client_secret = conf.get("oauth2", "client_secret", "")
+            if not client_id or not client_secret:
+                logger.warning(
+                    "OAuth2 is enabled but client_id or client_secret is not set. "
+                    "Using standard client instead."
+                )
+                use_oauth2 = False
 
         if use_http2 is None:
             use_http2 = conf.get("http2", "enabled", True, bool)
@@ -97,40 +127,42 @@ class HttpClientManager:
         # Create a cache key that includes the base URL, authentication and HTTP/2 settings
         cache_key = f"{origin}|oauth2={use_oauth2}|http2={use_http2}"
 
-        # Return cached client if it exists
+        # Fast path: cache hit. Don't take the lock if we don't have to.
         if cache_key in self._clients:
             return self._clients[cache_key]
 
-        # apply connection limits
-        max_conns = conf.get("fetch", "max_connections", 20, int)
-        limits = httpx.Limits(
-            max_connections=max_conns,
-            max_keepalive_connections=min(max_conns, 10),
-            keepalive_expiry=30.0,
-        )
+        # Slow path: serialize creation so two callers racing on the same
+        # cache key don't end up creating duplicate clients (and leaking
+        # whichever loses the race).
+        with self._client_lock:
+            if cache_key in self._clients:
+                return self._clients[cache_key]
 
-        # Normalize client base_url to origin to match cache key
-        normalized_base_url = origin
-
-        # Create a new client with the appropriate settings
-        if use_oauth2:
-            client = self.create_oauth2_client(
-                normalized_base_url, use_http2, limits=limits, headers=headers
-            )
-        else:
-            client = self.create_standard_client(
-                normalized_base_url, use_http2, limits=limits, headers=headers
+            max_conns = conf.get("fetch", "max_connections", 20, int)
+            limits = httpx.Limits(
+                max_connections=max_conns,
+                max_keepalive_connections=min(max_conns, 10),
+                keepalive_expiry=30.0,
             )
 
-        http2_version = "HTTP/2" if use_http2 else "HTTP/1.1"
-        if use_oauth2:
-            logger.info(f"Created OAuth2 client and using {http2_version} for {base_url}")
-        else:
-            logger.info(f"Created standard client and using {http2_version} for {base_url}")
+            # Normalize client base_url to origin to match cache key
+            normalized_base_url = origin
 
-        # Cache and return the client
-        self._clients[cache_key] = client
-        return client
+            if use_oauth2:
+                client = self.create_oauth2_client(
+                    normalized_base_url, use_http2, limits=limits, headers=headers
+                )
+            else:
+                client = self.create_standard_client(
+                    normalized_base_url, use_http2, limits=limits, headers=headers
+                )
+
+            http2_version = "HTTP/2" if use_http2 else "HTTP/1.1"
+            kind = "OAuth2 client" if use_oauth2 else "standard client"
+            logger.info("Created %s using %s for %s", kind, http2_version, base_url)
+
+            self._clients[cache_key] = client
+            return client
 
     def create_oauth2_client(
         self,
@@ -138,33 +170,21 @@ class HttpClientManager:
         use_http2: bool = True,
         limits: httpx.Limits = None,
         headers: Optional[dict] = None,
-    ) -> OAuth2Client | StandardClient:
+    ) -> OAuth2Client:
         """Create an OAuth2 client for the given base URL.
 
-        Args:
-            base_url: The base URL for the client.
-            use_http2: Whether to use HTTP/2.
-            limits: httpx.Limits instance
-
-        Returns:
-            OAuth2Client: The OAuth2 client.
+        Caller is expected to have already verified that ``client_id`` and
+        ``client_secret`` are configured — ``get_client`` does this and
+        falls back to ``create_standard_client`` when they aren't, so the
+        cache key and ``MwApi.use_oauth2`` agree on the auth choice.
         """
         client_id = conf.get("oauth2", "client_id", "")
         client_secret = conf.get("oauth2", "client_secret", "")
-
         token_url = conf.get(
             "oauth2", "token_url", "https://meta.wikimedia.org/w/rest.php/oauth2/access_token"
         )
 
-        if not client_id or not client_secret:
-            logger.warning(
-                "OAuth2 is enabled but client_id or client_secret is not set. "
-                "Using standard client instead."
-            )
-            return self.create_standard_client(base_url, use_http2, limits=limits, headers=headers)
-
-        # Create an OAuth2 client with client_credentials grant
-        client = OAuth2Client(
+        return OAuth2Client(
             client_id=client_id,
             client_secret=client_secret,
             token_endpoint=token_url,
@@ -176,8 +196,6 @@ class HttpClientManager:
             limits=limits,
         )
 
-        return client
-
     def create_standard_client(
         self,
         base_url: str,
@@ -185,15 +203,7 @@ class HttpClientManager:
         limits: httpx.Limits = None,
         headers: Optional[dict] = None,
     ) -> StandardClient:
-        """Create a standard HTTP client for the given base URL.
-
-        Args:
-            base_url: The base URL for the client.
-            use_http2: Whether to use HTTP/2.
-
-        Returns:
-            httpx.Client: The standard HTTP client.
-        """
+        """Create a standard HTTP client for the given base URL."""
         client = StandardClient(
             http2=use_http2,
             timeout=httpx.Timeout(30.0),
@@ -206,9 +216,7 @@ class HttpClientManager:
         return client
 
     def detect_http2_support(self, url: str) -> bool:
-        """Detect if the server at the given URL supports HTTP/2.
-        // ... existing code ...
-        """
+        """Detect if the server at the given URL supports HTTP/2."""
         origin = self._origin(url)
         now = time.time()
         cached = self._http2_support_cache.get(origin)
@@ -216,8 +224,14 @@ class HttpClientManager:
             return bool(cached.get("supported", False))
 
         try:
-            # Create a temporary client with HTTP/2 enabled
-            with StandardClient(http2=True) as client:
+            # Create a temporary client with HTTP/2 enabled. Cap the probe
+            # timeout aggressively — this fires once per origin during
+            # client creation, so a slow server here would otherwise block
+            # every first fetch behind a 30s connect.
+            with StandardClient(
+                http2=True,
+                timeout=httpx.Timeout(self._http2_probe_timeout_seconds),
+            ) as client:
                 # Make a HEAD request to check the HTTP version
                 response = client.head(url)
                 supported = response.http_version == "HTTP/2"

--- a/src/mwlib/network/http_client.py
+++ b/src/mwlib/network/http_client.py
@@ -22,23 +22,28 @@ from mwlib.utils import conf
 logger = logging.getLogger(__name__)
 
 
-def _oauth2_cache_identity() -> str:
-    """Return a fingerprint of the current OAuth2 config for cache keying.
+def oauth2_config_fingerprint() -> str:
+    """Compact fingerprint of the current OAuth2 config.
 
-    Two callers asking for OAuth2 against the same origin but with
-    different ``client_id`` / ``client_secret`` / ``token_url`` must NOT
-    share a cached client — otherwise a credential rotation (or a
-    multi-tenant test suite that swaps configs) silently keeps using the
-    old client. The secret is hashed so it never lands in logs or cache
-    keys in plaintext.
+    Hashes ``client_id`` + ``client_secret`` + ``token_url`` together so
+    cache keys stay short and don't leak the raw client_id / token_url
+    into debug dumps. Two callers asking for OAuth2 against the same
+    origin but with different credentials get different fingerprints,
+    so a credential rotation produces a fresh client rather than
+    silently reusing the old one.
     """
-    client_id = conf.get("oauth2", "client_id", "")
-    client_secret = conf.get("oauth2", "client_secret", "")
-    token_url = conf.get(
-        "oauth2", "token_url", "https://meta.wikimedia.org/w/rest.php/oauth2/access_token"
+    payload = "|".join(
+        [
+            conf.get("oauth2", "client_id", ""),
+            conf.get("oauth2", "client_secret", ""),
+            conf.get(
+                "oauth2",
+                "token_url",
+                "https://meta.wikimedia.org/w/rest.php/oauth2/access_token",
+            ),
+        ]
     )
-    secret_hash = hashlib.sha256(client_secret.encode("utf-8")).hexdigest()[:16]
-    return f"client_id={client_id}|token_url={token_url}|secret={secret_hash}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 class HttpClientManager:
@@ -81,21 +86,34 @@ class HttpClientManager:
 
     @staticmethod
     def _cache_key(origin: str, *, use_oauth2: bool, use_http2: bool) -> str:
-        """Build the cache key used by both ``get_client`` and ``invalidate_client``.
+        """Build the cache key used for looking up / inserting clients.
 
-        For OAuth2 clients the key includes a fingerprint of the
-        currently-configured credentials so that rotations create a fresh
-        client rather than reusing a stale-credential one. The secret is
-        hashed before being interpolated.
+        For OAuth2 the key includes a hashed fingerprint of the current
+        credentials so credential rotations produce a fresh client.
         """
-        auth_identity = _oauth2_cache_identity() if use_oauth2 else "standard"
+        auth_identity = oauth2_config_fingerprint() if use_oauth2 else "standard"
         return f"{origin}|oauth2={use_oauth2}|http2={use_http2}|auth={auth_identity}"
 
+    @staticmethod
+    def _cache_key_prefix(origin: str, *, use_oauth2: bool, use_http2: bool) -> str:
+        """Prefix matching every cache entry for this (origin, auth, http2) combo.
+
+        Ignores the OAuth fingerprint so callers can invalidate every
+        cached client for an origin even after credential rotation —
+        otherwise rotated-out clients would be unreachable through the
+        invalidate path.
+        """
+        return f"{origin}|oauth2={use_oauth2}|http2={use_http2}|auth="
+
     def invalidate_client(self, base_url: str, *, use_oauth2: bool, use_http2: bool) -> None:
+        """Drop every cached client matching the given (origin, auth, http2)."""
         origin = self._origin(base_url)
-        cache_key = self._cache_key(origin, use_oauth2=use_oauth2, use_http2=use_http2)
-        client = self._clients.pop(cache_key, None)
-        if client is not None:
+        prefix = self._cache_key_prefix(origin, use_oauth2=use_oauth2, use_http2=use_http2)
+        keys_to_remove = [k for k in list(self._clients) if k.startswith(prefix)]
+        for cache_key in keys_to_remove:
+            client = self._clients.pop(cache_key, None)
+            if client is None:
+                continue
             try:
                 client.close()
             except Exception:
@@ -123,14 +141,9 @@ class HttpClientManager:
         if use_oauth2 is None:
             use_oauth2 = conf.get("oauth2", "enabled", False, bool)
 
-        # Resolve OAuth2 *before* building the cache key. Falling back from
-        # OAuth2 to standard inside ``create_oauth2_client`` would otherwise
-        # leave a standard client cached under ``oauth2=True`` — and a
-        # later caller asking for OAuth2 would get that standard client
-        # back, while ``MwApi.use_oauth2`` stayed True and tried to call
-        # ``fetch_token`` on a non-OAuth2 client. By deciding here, both
-        # the cache key and the eventual ``isinstance`` check on the
-        # returned client agree.
+        # Resolve OAuth2 fallback *before* building the cache key, so a
+        # missing-creds fallback caches under ``oauth2=False`` and
+        # ``MwApi.use_oauth2`` (set from the actual client type) agrees.
         if use_oauth2:
             client_id = conf.get("oauth2", "client_id", "")
             client_secret = conf.get("oauth2", "client_secret", "")
@@ -144,10 +157,8 @@ class HttpClientManager:
         if use_http2 is None:
             use_http2 = conf.get("http2", "enabled", True, bool)
 
-        # Auto-detect HTTP/2 support if configured. Probe the origin
-        # rather than the full ``api.php?...`` URL — heavy routes can
-        # take significantly longer to HEAD, and the result is cached
-        # per-origin anyway so the probe only hits one endpoint.
+        # Probe the origin rather than the full URL — heavy routes can
+        # be slow to HEAD and the result is cached per-origin anyway.
         if use_http2 and conf.get("http2", "auto_detect", True, bool):
             use_http2 = self.detect_http2_support(self._origin(base_url))
 
@@ -159,18 +170,13 @@ class HttpClientManager:
 
         headers["User-Agent"] = getattr(conf, "user_agent", "mwlib")
 
-        # Cache key includes the base URL, the auth choice, the HTTP/2
-        # decision, and (for OAuth2) a fingerprint of the credentials so
-        # rotations don't reuse a stale-cred client.
         cache_key = self._cache_key(origin, use_oauth2=use_oauth2, use_http2=use_http2)
 
-        # Fast path: cache hit. Don't take the lock if we don't have to.
+        # Fast path: cache hit, no lock needed.
         if cache_key in self._clients:
             return self._clients[cache_key]
 
-        # Slow path: serialize creation so two callers racing on the same
-        # cache key don't end up creating duplicate clients (and leaking
-        # whichever loses the race).
+        # Slow path: lock so two callers don't both build the client.
         with self._client_lock:
             if cache_key in self._clients:
                 return self._clients[cache_key]

--- a/src/mwlib/network/sapi.py
+++ b/src/mwlib/network/sapi.py
@@ -8,9 +8,7 @@ import logging
 import random
 import time
 from collections import deque
-from http import cookiejar
 from urllib import parse
-from urllib.error import HTTPError, URLError
 
 try:
     import simplejson as json
@@ -226,13 +224,17 @@ class MwApi:
         return response.content
 
     def _retry_or_raise(self, *, url, error, retry_state, retry_policy):
+        # Use ``gevent.sleep`` so retry backoff cooperates with the
+        # gevent hub. ``time.sleep`` would block the entire event loop
+        # and starve every other greenlet sharing the worker — same
+        # reasoning as ``RateLimiter.acquire``.
         return network_api.retry_or_raise(
             url=url,
             error=error,
             retry_state=retry_state,
             retry_policy=retry_policy,
             logger=logger,
-            sleep_fn=time.sleep,
+            sleep_fn=gevent.sleep,
             uniform_fn=random.uniform,
         )
 
@@ -364,6 +366,20 @@ class MwApi:
         res = loads(data)
         return res
 
+    def _oauth_token_cache_key(self):
+        """Cache key for the OAuth token in ``_token_info``.
+
+        Including the OAuth client_id and token endpoint means two
+        OAuth configurations against the same wiki (credential rotation,
+        multi-tenant runs) get separate token state instead of stepping
+        on each other's access tokens. Falls back to bare domain for
+        non-OAuth callers.
+        """
+        parsed = parse.urlparse(self.apiurl)
+        client_id = getattr(self.http_client, "client_id", "") or ""
+        token_endpoint = getattr(self.http_client, "token_endpoint", "") or ""
+        return f"{parsed.netloc}|client_id={client_id}|token_endpoint={token_endpoint}"
+
     def _ensure_oauth2_token(self):
         network_auth.ensure_oauth2_token(
             enabled=self.use_oauth2,
@@ -372,6 +388,7 @@ class MwApi:
             http_client=self.http_client,
             logger=logger,
             current_time_fn=time.time,
+            cache_key=self._oauth_token_cache_key() if self.use_oauth2 else None,
         )
 
     def do_request(self, use_post=False, **kwargs):

--- a/src/mwlib/network/sapi.py
+++ b/src/mwlib/network/sapi.py
@@ -17,7 +17,9 @@ try:
 except ImportError:
     import json
 
+import gevent
 import httpx
+from authlib.integrations.httpx_client import OAuth2Client
 from gevent.lock import Semaphore
 
 from mwlib.core import authors
@@ -73,7 +75,13 @@ class RateLimiter:
         self._lock = Semaphore(1)
 
     def acquire(self):
-        """Block until a request is allowed under the rate limit."""
+        """Block (cooperatively) until a request is allowed under the rate limit.
+
+        This runs inside the gevent-based fetcher; ``time.sleep`` would
+        block the entire hub and starve every other greenlet. ``gevent.sleep``
+        yields to the scheduler so unrelated requests keep flowing while
+        this caller is throttled.
+        """
         while True:
             with self._lock:
                 now = time.monotonic()
@@ -88,7 +96,7 @@ class RateLimiter:
                 # Calculate how long to wait until the oldest entry expires
                 wait_time = self._period - (now - self._timestamps[0])
 
-            time.sleep(max(wait_time, 0.01))
+            gevent.sleep(max(wait_time, 0.01))
 
 
 class MwApi:
@@ -104,7 +112,7 @@ class MwApi:
         self.baseurl = apiurl  # XXX
 
         # Determine whether to use OAuth2 and HTTP/2 from configuration if not specified
-        self.use_oauth2 = (
+        requested_oauth2 = (
             use_oauth2 if use_oauth2 is not None else conf.get("oauth2", "enabled", False, bool)
         )
         self.use_http2 = (
@@ -113,12 +121,22 @@ class MwApi:
 
         # Get HTTP client from manager
         self.http_client = HttpClientManager.get_instance().get_client(
-            self.apiurl, use_oauth2=self.use_oauth2, use_http2=self.use_http2
+            self.apiurl, use_oauth2=requested_oauth2, use_http2=self.use_http2
         )
 
-        # Set basic auth if username is provided and OAuth2 is not enabled
+        # Trust the actual client type rather than what we asked for. If
+        # OAuth2 was requested but credentials are missing, ``get_client``
+        # falls back to a standard client; ``_ensure_oauth2_token`` would
+        # otherwise call ``fetch_token`` on a non-OAuth2 client and fail.
+        self.use_oauth2 = isinstance(self.http_client, OAuth2Client)
+
+        # Basic Auth lives per-instance and is passed per request. It used
+        # to be set on the shared ``http_client.auth``, which leaked
+        # credentials across every other ``MwApi`` sharing the same origin
+        # (and would silently be overwritten by the next caller).
+        self.basic_auth = None
         if username and not self.use_oauth2:
-            self.http_client.auth = httpx.BasicAuth(username, password or "")
+            self.basic_auth = httpx.BasicAuth(username, password or "")
 
         self.edittoken = None
         self.qccount = 0
@@ -170,9 +188,7 @@ class MwApi:
                 limiter = RateLimiter(max_calls=max_rps, period=1.0)
                 MwApi._rate_limiters[origin] = limiter
                 MwApi._rate_limiter_rps[origin] = max_rps
-                logger.info(
-                    f"Rate limiter initialized for {origin}: {max_rps} requests/second"
-                )
+                logger.info(f"Rate limiter initialized for {origin}: {max_rps} requests/second")
 
         limiter.acquire()
 
@@ -198,10 +214,14 @@ class MwApi:
         return request_headers
 
     def _send_http_request(self, method, url, data, request_headers):
+        # ``auth`` is passed per-request so two MwApi instances sharing
+        # the underlying httpx client (same origin) don't clobber each
+        # other's credentials.
+        auth = self.basic_auth
         if method == "POST":
-            response = self.http_client.post(url, data=data, headers=request_headers)
+            response = self.http_client.post(url, data=data, headers=request_headers, auth=auth)
         else:
-            response = self.http_client.get(url, headers=request_headers)
+            response = self.http_client.get(url, headers=request_headers, auth=auth)
         response.raise_for_status()
         return response.content
 

--- a/src/mwlib/network/sapi.py
+++ b/src/mwlib/network/sapi.py
@@ -23,7 +23,7 @@ from gevent.lock import Semaphore
 from mwlib.core import authors
 from mwlib.network import api as network_api
 from mwlib.network import auth as network_auth
-from mwlib.network.http_client import HttpClientManager
+from mwlib.network.http_client import HttpClientManager, oauth2_config_fingerprint
 from mwlib.utils import conf
 
 logger = logging.getLogger(__name__)
@@ -98,11 +98,14 @@ class RateLimiter:
 
 
 class MwApi:
-    # Track domains and their token expiration timestamps
-    _token_info = {}  # Format: {domain: {'token': token, 'expires_at': timestamp}}
-    request_counter = 0
-    _rate_limiters = {}  # Format: {origin: RateLimiter}
-    _rate_limiter_rps = {}  # Format: {origin: max_rps}
+    # Token state and rate-limit state are shared across MwApi instances
+    # because two MwApis for the same wiki should reuse the same token /
+    # the same per-origin rate limiter. ``request_counter`` is per
+    # instance — see ``__init__`` — to avoid the class attribute being
+    # silently shadowed on first increment via ``self``.
+    _token_info = {}  # {token-cache-key: {token, expires_at, ...}}
+    _rate_limiters = {}  # {origin: RateLimiter}
+    _rate_limiter_rps = {}  # {origin: max_rps}
     _rate_limiter_lock = Semaphore(1)
 
     def __init__(self, apiurl, username=None, password=None, use_oauth2=None, use_http2=None):
@@ -138,6 +141,11 @@ class MwApi:
 
         self.edittoken = None
         self.qccount = 0
+        # Per-instance: incrementing through ``self.request_counter`` used
+        # to silently shadow the class-level default after the first call,
+        # which made the test fixture's ``MwApi.request_counter = 0`` reset
+        # ineffective for any instance that had already issued a request.
+        self.request_counter = 0
         self.api_result_limit = conf.get("fetch", "api_result_limit", 500, int)
         self.api_request_limit = conf.get("fetch", "api_request_limit", 15, int)
         self.max_connections = conf.get("fetch", "max_connections", 20, int)
@@ -367,18 +375,16 @@ class MwApi:
         return res
 
     def _oauth_token_cache_key(self):
-        """Cache key for the OAuth token in ``_token_info``.
+        """Token cache key — fingerprints the full OAuth identity.
 
-        Including the OAuth client_id and token endpoint means two
-        OAuth configurations against the same wiki (credential rotation,
-        multi-tenant runs) get separate token state instead of stepping
-        on each other's access tokens. Falls back to bare domain for
-        non-OAuth callers.
+        ``HttpClientManager`` already separates clients by credential
+        fingerprint; the token cache must match. Without the secret
+        fingerprint here, a credential rotation produces a fresh client
+        but the new client could still pick up the old client's cached
+        access token until expiry.
         """
         parsed = parse.urlparse(self.apiurl)
-        client_id = getattr(self.http_client, "client_id", "") or ""
-        token_endpoint = getattr(self.http_client, "token_endpoint", "") or ""
-        return f"{parsed.netloc}|client_id={client_id}|token_endpoint={token_endpoint}"
+        return f"{parsed.netloc}|oauth={oauth2_config_fingerprint()}"
 
     def _ensure_oauth2_token(self):
         network_auth.ensure_oauth2_token(

--- a/src/mwlib/parser/templ/magics.py
+++ b/src/mwlib/parser/templ/magics.py
@@ -69,7 +69,7 @@ def urlquote(url: str) -> str:
 
 
 class OtherMagic:
-    def DEFAULTSORT(self) -> str:
+    def DEFAULTSORT(self, args=None) -> str:
         """see https://en.wikipedia.org/wiki/Template:DEFAULTSORT"""
         return ""
 

--- a/src/mwlib/rendering/licensechecker.py
+++ b/src/mwlib/rendering/licensechecker.py
@@ -114,6 +114,16 @@ class LicenseChecker:
             return False
         return filter_type in ["blacklist", "nofilter"]
 
+    def decide_from_template_names(self, template_names):
+        """Public helper: license decision from a list of template name strings.
+
+        Wraps the ``_get_licenses`` lookup + ``license_passes_filter``
+        policy so callers don't need to reach into the private
+        ``_get_licenses`` to make a fetch-time decision.
+        """
+        lowered = [t.lower() for t in template_names]
+        return self.license_passes_filter(self._get_licenses(lowered), self.filter_type)
+
     def _check_licenses(self, licenses, imgname, stats=True):
         if not self.image_db:
             raise ImageDbError("No image_db passed when initializing LicenseChecker")

--- a/src/mwlib/rendering/licensechecker.py
+++ b/src/mwlib/rendering/licensechecker.py
@@ -17,8 +17,7 @@ except ImportError:
 
 
 class License:
-    def __init__(self, name="", display_name="",
-                 license_type=None, description=""):
+    def __init__(self, name="", display_name="", license_type=None, description=""):
         self.name = name
         self.display_name = display_name
         self.license_type = license_type  # free|nonfree|unrelated|unknown
@@ -58,8 +57,7 @@ class LicenseChecker:
         with open(file_name) as csv_file:
             for data in csv.reader(csv_file):
                 try:
-                    (name, display_name, license_type,
-                     _, license_description) = data
+                    (name, display_name, license_type, _, license_description) = data
                 except ValueError:
                     continue
                 if not name:
@@ -97,43 +95,59 @@ class LicenseChecker:
             licenses.append(lic)
         return licenses
 
-    def _check_licenses(self, licenses, imgname, stats=True):
-        if not self.image_db:
-            raise ImageDbError(
-                "No image_db passed when initializing LicenseChecker")
+    @staticmethod
+    def license_passes_filter(licenses, filter_type):
+        """Pure policy: decide whether a list of License objects passes the filter.
+
+        Pulled out so fetch-time license checking (where there's no
+        ``image_db`` and stats aren't needed) can use the exact same policy
+        as render-time. Keep this in sync with ``_check_licenses`` —
+        anything that affects the True/False decision belongs here, while
+        side effects (stats, display_name caching) stay on the instance.
+        """
         for lic in licenses:
             if lic.license_type == "free":
-                self.license_display_name[imgname] = lic.display_name
                 return True
-            elif lic.license_type == "nonfree":
-                self.license_display_name[imgname] = lic.display_name
-                return self.filter_type == "nofilter"
-        for lic in licenses:
-            if lic.license_type == "unknown" and stats:
-                urls = self.unknown_licenses.get(lic.name, set())
-                urls.add(
-                    self.image_db.get_description_url(imgname)
-                    or self.image_db.get_url(imgname)
-                    or imgname
-                )
-                self.unknown_licenses[lic.name] = urls
-        self.license_display_name[imgname] = ""
-        if self.filter_type == "whitelist":
+            if lic.license_type == "nonfree":
+                return filter_type == "nofilter"
+        if filter_type == "whitelist":
             return False
-        elif self.filter_type in ["blacklist", "nofilter"]:
-            return True
+        return filter_type in ["blacklist", "nofilter"]
+
+    def _check_licenses(self, licenses, imgname, stats=True):
+        if not self.image_db:
+            raise ImageDbError("No image_db passed when initializing LicenseChecker")
+        # Side effect: cache the display name for the first matching license
+        # (so get_license_display_name returns something useful for this image).
+        for lic in licenses:
+            if lic.license_type in ("free", "nonfree"):
+                self.license_display_name[imgname] = lic.display_name
+                break
+        else:
+            self.license_display_name[imgname] = ""
+            if stats:
+                for lic in licenses:
+                    if lic.license_type == "unknown":
+                        urls = self.unknown_licenses.get(lic.name, set())
+                        urls.add(
+                            self.image_db.get_description_url(imgname)
+                            or self.image_db.get_url(imgname)
+                            or imgname
+                        )
+                        self.unknown_licenses[lic.name] = urls
+        return self.license_passes_filter(licenses, self.filter_type)
 
     def display_image(self, imgname):
         if imgname in self.display_cache:
             return self.display_cache[imgname]
         if self.image_db is None:
             return False
-        templates = [t.lower() for t in self.image_db.get_image_templates_and_args(
-            imgname)]
+        templates = [t.lower() for t in self.image_db.get_image_templates_and_args(imgname)]
         licenses = self._get_licenses(templates)
         display_img = self._check_licenses(licenses, imgname)
-        url = self.image_db.get_description_url(imgname) or self.image_db.get_url(
-            imgname) or imgname
+        url = (
+            self.image_db.get_description_url(imgname) or self.image_db.get_url(imgname) or imgname
+        )
         if display_img:
             self.accepted_images.add(url)
         else:
@@ -153,25 +167,26 @@ class LicenseChecker:
     def free_img_ratio(self):
         num_rejected_images = len(self.rejected_images)
         num_accepted_images = len(self.accepted_images)
-        ratio = num_accepted_images / (num_accepted_images + num_rejected_images) if num_accepted_images + num_rejected_images > 0 else 1
+        ratio = (
+            num_accepted_images / (num_accepted_images + num_rejected_images)
+            if num_accepted_images + num_rejected_images > 0
+            else 1
+        )
         return ratio
 
     def dump_stats(self):
         stats = [
             "IMAGE LICENSE STATS - accepted: %d - rejected: %d --> accept ratio: %.2f"
-            % (len(self.accepted_images), len(self.rejected_images),
-               self.free_img_ratio)
+            % (len(self.accepted_images), len(self.rejected_images), self.free_img_ratio)
         ]
 
         images = set()
         for urls in self.unknown_licenses.values():
             for url in urls:
                 images.add(repr(url))
-        stats.append("Images without license information: %s" % (" ".join(
-            list(images))))
+        stats.append("Images without license information: %s" % (" ".join(list(images))))
         stats.append("##############################")
-        stats.append("Rejected Images: %s" % " ".join(
-            list(self.rejected_images)))
+        stats.append("Rejected Images: %s" % " ".join(list(self.rejected_images)))
         return "\n".join(stats)
 
     def dump_unknown_licenses(self, _dir):
@@ -204,12 +219,10 @@ class LicenseChecker:
                     seen_urls = unknown_licenses.get(lic, set())
                     seen_urls.update(set(urls))
                     unknown_licenses[lic] = seen_urls
-        sorted_licenses = [
-            (len(urls), lic, urls) for lic, urls in unknown_licenses.items()
-        ]
+        sorted_licenses = [(len(urls), lic, urls) for lic, urls in unknown_licenses.items()]
         sorted_licenses.sort(reverse=True)
         for num_urls, lic, urls in sorted_licenses:
-            img_str = "\n".join(list(list(urls)[:5])),
+            img_str = ("\n".join(list(list(urls)[:5])),)
             print(f"\nTEMPLATE: {lic} (num rejected images: {num_urls})\nIMAGES:\n{img_str}\n")
 
     def dump_license_info_content(self):
@@ -244,11 +257,9 @@ if __name__ == "__main__":
     lc = LicenseChecker()
     lc.read_licenses_csv()
 
-    STATS_DIR = sys.argv[1] if len(sys.argv) > 1 else os.environ.get(
-        "HIQ_STATSDIR")
+    STATS_DIR = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("HIQ_STATSDIR")
     if not STATS_DIR:
-        print(
-            "specify stats_dir as first arg, or set environment var HIQ_STATSIDR")
+        print("specify stats_dir as first arg, or set environment var HIQ_STATSIDR")
         sys.exit(1)
 
     lc.analyse_unknown_licenses(STATS_DIR)

--- a/src/mwlib/utils/_conf.py
+++ b/src/mwlib/utils/_conf.py
@@ -77,6 +77,14 @@ class ConfMod:
             "fetch": {
                 "noedits": "False",
             },
+            "bigquery": {
+                "enabled": "false",
+                "project": "",
+                "dataset": "wme_snapshots",
+                "table": "file_pages",
+                "timeout": "30",
+                "domains": "en.wikipedia.org",
+            },
         }
 
         self.config = configparser.ConfigParser()

--- a/tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
+++ b/tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
@@ -1,96 +1,564 @@
-"""Targeted tests for ``fetch_wikimedia_snapshot``.
+"""Unit tests for the WME snapshot ingestion script.
 
-Focused on the security-sensitive tar extraction path. The full ingestion
-path (download, BigQuery load) is exercised by ops runs rather than unit
-tests because it requires WME credentials and a real BigQuery target.
+These tests cover the pure-functional parts (per-namespace row parsers,
+namespace dispatch, CLI argument handling) and the table-prep / disk-usage
+behaviour that matters for NS0's larger volume.
+
+They never touch BigQuery, the WME API, or the network — load-job and
+streaming-insert paths use a mocked BigQuery client.
 """
 
 from __future__ import annotations
 
 import io
+import json
 import tarfile
+from unittest.mock import MagicMock
 
 import pytest
 
-from mwlib.apps.fetch_wikimedia_snapshot import extract_ndjson_from_tarball
+from mwlib.apps import fetch_wikimedia_snapshot as snap
+
+# ---------------------------------------------------------------------------
+# NS6 row parser
+# ---------------------------------------------------------------------------
 
 
-def _add_regular_file(tar, name, content):
-    info = tarfile.TarInfo(name=name)
-    data = content.encode("utf-8")
-    info.size = len(data)
-    tar.addfile(info, io.BytesIO(data))
+class TestParseNs6Row:
+    def test_extracts_image_metadata(self):
+        line = json.dumps(
+            {
+                "name": "File:Example.jpg",
+                "identifier": 42,
+                "url": "https://en.wikipedia.org/wiki/File:Example.jpg",
+                "date_modified": "2025-01-01T00:00:00Z",
+                "license": [{"name": "CC-BY-SA-4.0"}],
+                "templates": [{"name": "Template:Information"}],
+                "categories": [{"name": "Category:Photos"}],
+                "abstract": "Sample image",
+                "image": {
+                    "content_url": "https://upload.wikimedia.org/Example.jpg",
+                    "width": 1200,
+                    "height": 800,
+                },
+            }
+        )
+
+        row = snap.parse_ns6_row(line)
+
+        assert row["name"] == "File:Example.jpg"
+        assert row["identifier"] == 42
+        assert row["image_width"] == 1200
+        assert row["image_height"] == 800
+        assert row["image_content_url"] == "https://upload.wikimedia.org/Example.jpg"
+        assert json.loads(row["license"]) == [{"name": "CC-BY-SA-4.0"}]
+        assert json.loads(row["templates"]) == [{"name": "Template:Information"}]
+        assert json.loads(row["categories"]) == [{"name": "Category:Photos"}]
+
+    def test_handles_missing_image_block(self):
+        # Non-image file pages (e.g. MP3) have no image dict — width/height
+        # must come back unset rather than crashing.
+        line = json.dumps({"name": "File:Audio.mp3", "identifier": 1})
+        row = snap.parse_ns6_row(line)
+        assert row["name"] == "File:Audio.mp3"
+        assert "image_width" not in row
+        assert "image_height" not in row
+
+    def test_skips_missing_name(self):
+        line = json.dumps({"identifier": 1})
+        assert snap.parse_ns6_row(line) is None
+
+    def test_skips_malformed_json(self):
+        assert snap.parse_ns6_row("not json") is None
 
 
-def _add_symlink(tar, name, target):
-    info = tarfile.TarInfo(name=name)
-    info.type = tarfile.SYMTYPE
-    info.linkname = target
-    tar.addfile(info)
+# ---------------------------------------------------------------------------
+# NS0 row parser
+# ---------------------------------------------------------------------------
 
 
-def _add_hardlink(tar, name, target):
-    info = tarfile.TarInfo(name=name)
-    info.type = tarfile.LNKTYPE
-    info.linkname = target
-    tar.addfile(info)
+class TestParseNs0Row:
+    def test_keeps_only_lean_schema_fields(self):
+        # WME NS0 records carry many fields we explicitly do not want to
+        # store. The parser must keep just (name, identifier, date_modified,
+        # article_body_html) and drop everything else, regardless of how big
+        # the input record is.
+        line = json.dumps(
+            {
+                "name": "Mainz",
+                "identifier": 99,
+                "url": "https://en.wikipedia.org/wiki/Mainz",
+                "date_modified": "2025-01-01T00:00:00Z",
+                "abstract": "Mainz is a city in Germany.",
+                "version": {"identifier": 12345, "comment": "edit"},
+                "in_language": {"identifier": "en"},
+                "main_entity": {"identifier": "Q1726"},
+                "license": [{"name": "CC-BY-SA-4.0"}],
+                "templates": [{"name": "Template:Infobox"}],
+                "categories": [{"name": "Category:Cities"}],
+                "redirects": [{"name": "Mayence"}],
+                "article_body": {
+                    "html": "<p>Mainz is a city.</p>",
+                    "wikitext": "Mainz is a city.",
+                },
+            }
+        )
+
+        row = snap.parse_ns0_row(line)
+
+        assert row == {
+            "name": "Mainz",
+            "identifier": 99,
+            "date_modified": "2025-01-01T00:00:00Z",
+            "article_body_html": "<p>Mainz is a city.</p>",
+        }
+        # Critical for storage cost — none of these may leak into the row
+        for forbidden in (
+            "abstract",
+            "version",
+            "in_language",
+            "main_entity",
+            "license",
+            "templates",
+            "categories",
+            "redirects",
+            "url",
+            "wikitext",
+        ):
+            assert forbidden not in row
+
+    def test_skips_row_without_html(self):
+        # Without HTML there is nothing the page-count estimator can do —
+        # storing the row would just bloat the table with empty placeholders.
+        line = json.dumps({"name": "Empty", "identifier": 1, "article_body": {"wikitext": "x"}})
+        assert snap.parse_ns0_row(line) is None
+
+    def test_skips_row_with_empty_html(self):
+        line = json.dumps({"name": "Empty", "article_body": {"html": ""}})
+        assert snap.parse_ns0_row(line) is None
+
+    def test_skips_row_without_article_body(self):
+        line = json.dumps({"name": "NoBody", "identifier": 7})
+        assert snap.parse_ns0_row(line) is None
+
+    def test_skips_missing_name(self):
+        line = json.dumps({"identifier": 1, "article_body": {"html": "<p>x</p>"}})
+        assert snap.parse_ns0_row(line) is None
+
+    def test_skips_malformed_json(self):
+        assert snap.parse_ns0_row("not json") is None
 
 
-class TestExtractNdjsonFromTarball:
-    def test_extracts_regular_ndjson_files(self, tmp_path):
-        tarball = tmp_path / "snap.tar.gz"
-        with tarfile.open(tarball, "w:gz") as tar:
-            _add_regular_file(tar, "a.ndjson", '{"x": 1}\n')
-            _add_regular_file(tar, "b.ndjson", '{"x": 2}\n')
+# ---------------------------------------------------------------------------
+# Namespace dispatch
+# ---------------------------------------------------------------------------
 
-        paths = extract_ndjson_from_tarball(tarball)
 
-        assert sorted(p.name for p in paths) == ["a.ndjson", "b.ndjson"]
-        assert all(p.read_text().strip() for p in paths)
+class TestNamespaceConfig:
+    def test_ns6_targets_file_pages_and_recreates_table(self):
+        ns = snap.NAMESPACES[6]
+        assert ns.table_id == "file_pages"
+        assert ns.snapshot_id == "enwiki_namespace_6"
+        assert ns.parser is snap.parse_ns6_row
+        assert ns.script_manages_table is True
+
+    def test_ns0_targets_article_pages_and_defers_to_pulumi(self):
+        ns = snap.NAMESPACES[0]
+        assert ns.table_id == "article_pages"
+        assert ns.snapshot_id == "enwiki_namespace_0"
+        assert ns.parser is snap.parse_ns0_row
+        # Pulumi owns the table layout; the script must not drop it.
+        assert ns.script_manages_table is False
+
+    def test_ns0_schema_is_minimal(self):
+        ns = snap.NAMESPACES[0]
+        field_names = {f["name"] for f in ns.schema}
+        assert field_names == {
+            "name",
+            "identifier",
+            "date_modified",
+            "article_body_html",
+        }
+        # name is the lookup key — must be REQUIRED so BigQuery rejects bad
+        # rows up front rather than silently storing them.
+        assert next(f for f in ns.schema if f["name"] == "name")["mode"] == "REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# Table preparation strategy
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareTable:
+    def test_ns6_recreates_the_table(self):
+        client = MagicMock()
+        ns = snap.NAMESPACES[6]
+        snap._prepare_table(client, "p.d.file_pages", ns)
+        client.delete_table.assert_called_once_with("p.d.file_pages", not_found_ok=True)
+        client.create_table.assert_called_once()
+        _, kwargs = client.create_table.call_args
+        assert "exists_ok" not in kwargs
+
+    def test_ns0_does_not_drop_the_table(self):
+        client = MagicMock()
+        ns = snap.NAMESPACES[0]
+        snap._prepare_table(client, "p.d.article_pages", ns)
+        client.delete_table.assert_not_called()
+        # exists_ok=True so the call is a no-op when Pulumi has already
+        # provisioned the table (production), and a bootstrap when it hasn't (dev).
+        client.create_table.assert_called_once()
+        _, kwargs = client.create_table.call_args
+        assert kwargs.get("exists_ok") is True
+
+
+# ---------------------------------------------------------------------------
+# CLI argument handling
+# ---------------------------------------------------------------------------
+
+
+class TestArgParser:
+    def test_default_namespace_is_six(self):
+        args = snap._build_arg_parser().parse_args([])
+        assert args.namespace == 6
+
+    def test_namespace_can_select_zero(self):
+        args = snap._build_arg_parser().parse_args(["--namespace", "0"])
+        assert args.namespace == 0
+
+    def test_invalid_namespace_rejected(self):
+        with pytest.raises(SystemExit):
+            snap._build_arg_parser().parse_args(["--namespace", "1"])
+
+    def test_snapshot_id_defaults_per_namespace(self):
+        args0 = snap._build_arg_parser().parse_args(["--namespace", "0"])
+        ns0 = snap.NAMESPACES[args0.namespace]
+        assert (args0.snapshot_id or ns0.snapshot_id) == "enwiki_namespace_0"
+
+        args6 = snap._build_arg_parser().parse_args([])
+        ns6 = snap.NAMESPACES[args6.namespace]
+        assert (args6.snapshot_id or ns6.snapshot_id) == "enwiki_namespace_6"
+
+
+# ---------------------------------------------------------------------------
+# Tarball iteration: just-in-time extract + delete
+# ---------------------------------------------------------------------------
+
+
+def _make_tarball(tmp_path, files: dict[str, str]):
+    """Write a .tar.gz containing the given filename → content map."""
+    tarball = tmp_path / "snapshot.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        for name, content in files.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return tarball
+
+
+class TestIterExtractNdjson:
+    """The iterator must cap peak disk usage at one extracted NDJSON.
+
+    Concretely: extract one NDJSON, yield it, then delete it before extracting
+    the next. The output is "tarball + at most one extracted NDJSON" on disk
+    at any moment.
+    """
+
+    def test_yields_each_ndjson_in_order(self, tmp_path):
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "chunk_0.ndjson": '{"a": 1}\n',
+                "chunk_1.ndjson": '{"a": 2}\n',
+                "chunk_2.ndjson": '{"a": 3}\n',
+            },
+        )
+
+        seen = []
+        for path in snap.iter_extract_ndjson(tarball):
+            seen.append((path.name, path.read_text()))
+
+        assert [n for n, _ in seen] == [
+            "chunk_0.ndjson",
+            "chunk_1.ndjson",
+            "chunk_2.ndjson",
+        ]
+
+    def test_deletes_extracted_file_after_each_iteration(self, tmp_path):
+        # Only one extracted NDJSON is on disk at a time. Capture each
+        # extracted path, advance the iterator, and assert the previous
+        # extracted file no longer exists.
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "a.ndjson": "x\n",
+                "b.ndjson": "y\n",
+                "c.ndjson": "z\n",
+            },
+        )
+
+        it = snap.iter_extract_ndjson(tarball)
+        first = next(it)
+        assert first.exists()
+
+        second = next(it)
+        assert second.exists()
+        assert not first.exists(), (
+            "first NDJSON should have been deleted before the second was yielded"
+        )
+
+        third = next(it)
+        assert third.exists()
+        assert not second.exists()
+
+        with pytest.raises(StopIteration):
+            next(it)
+        assert not third.exists(), "last NDJSON should be deleted when iteration completes"
+
+    def test_skips_non_ndjson_members(self, tmp_path):
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "README.txt": "ignore me",
+                "data.ndjson": '{"a": 1}\n',
+            },
+        )
+        names = [p.name for p in snap.iter_extract_ndjson(tarball)]
+        assert names == ["data.ndjson"]
 
     def test_rejects_path_traversal(self, tmp_path):
-        tarball = tmp_path / "snap.tar.gz"
-        with tarfile.open(tarball, "w:gz") as tar:
-            _add_regular_file(tar, "../escape.ndjson", "x\n")
-
+        tarball = _make_tarball(tmp_path, {"../escape.ndjson": "evil\n"})
+        it = snap.iter_extract_ndjson(tarball)
         with pytest.raises(ValueError, match="Suspicious tar member path"):
-            extract_ndjson_from_tarball(tarball)
+            next(it)
 
     def test_rejects_absolute_path(self, tmp_path):
-        tarball = tmp_path / "snap.tar.gz"
-        with tarfile.open(tarball, "w:gz") as tar:
-            _add_regular_file(tar, "/etc/passwd.ndjson", "x\n")
-
+        tarball = _make_tarball(tmp_path, {"/etc/passwd.ndjson": "evil\n"})
+        it = snap.iter_extract_ndjson(tarball)
         with pytest.raises(ValueError, match="Suspicious tar member path"):
-            extract_ndjson_from_tarball(tarball)
+            next(it)
 
     def test_rejects_symlink_member(self, tmp_path):
-        """A crafted tarball must not be able to write *through* a symlink.
+        """A crafted symlink ending in .ndjson must not be extracted.
 
-        Symlinks ending in ``.ndjson`` would otherwise be passed to
-        ``tar.extract``, which happily creates the symlink and then a
-        subsequent extracted file written to that name follows it out
-        of the target directory.
+        Without the regular-file check, ``tar.extract`` would happily
+        create the symlink and a follow-up extracted file written to
+        that name would land outside the target directory.
         """
         tarball = tmp_path / "snap.tar.gz"
         with tarfile.open(tarball, "w:gz") as tar:
-            _add_symlink(tar, "evil.ndjson", "/tmp/evil-target")
+            for name, content in {"good.ndjson": '{"x": 1}\n'}.items():
+                data = content.encode("utf-8")
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+            # …and append a symlink alongside the legit file.
+            link = tarfile.TarInfo(name="evil.ndjson")
+            link.type = tarfile.SYMTYPE
+            link.linkname = "/tmp/evil-target"
+            tar.addfile(link)
 
+        it = snap.iter_extract_ndjson(tarball)
         with pytest.raises(ValueError, match="non-regular tar member"):
-            extract_ndjson_from_tarball(tarball)
+            next(it)
 
     def test_rejects_hardlink_member(self, tmp_path):
         tarball = tmp_path / "snap.tar.gz"
         with tarfile.open(tarball, "w:gz") as tar:
-            _add_hardlink(tar, "evil.ndjson", "../something")
+            for name, content in {"good.ndjson": '{"x": 1}\n'}.items():
+                data = content.encode("utf-8")
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+            link = tarfile.TarInfo(name="evil.ndjson")
+            link.type = tarfile.LNKTYPE
+            link.linkname = "../something"
+            tar.addfile(link)
 
+        it = snap.iter_extract_ndjson(tarball)
         with pytest.raises(ValueError, match="non-regular tar member"):
-            extract_ndjson_from_tarball(tarball)
+            next(it)
 
-    def test_no_ndjson_raises(self, tmp_path):
-        tarball = tmp_path / "snap.tar.gz"
-        with tarfile.open(tarball, "w:gz") as tar:
-            _add_regular_file(tar, "README.md", "x\n")
+    def test_rejects_tarball_with_no_ndjson(self, tmp_path):
+        tarball = _make_tarball(tmp_path, {"only_a_txt.txt": "no ndjson here"})
+        it = snap.iter_extract_ndjson(tarball)
+        with pytest.raises(ValueError, match="No .ndjson files found"):
+            next(it)
 
-        with pytest.raises(ValueError, match="No .ndjson files"):
-            extract_ndjson_from_tarball(tarball)
+
+# ---------------------------------------------------------------------------
+# load_tarball_to_bigquery: end-to-end load-job dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTarballLoadJob:
+    """Full path: tarball → iter-extract → per-file load job.
+
+    Verifies the disposition sequence (truncate then append) and the
+    just-in-time disk cleanup.
+    """
+
+    def _setup_client(self, monkeypatch):
+        from google.cloud import bigquery  # noqa: F401  (used by SUT)
+
+        client = MagicMock()
+        load_job = MagicMock()
+        load_job.errors = None
+        load_job.output_rows = 1
+        load_job.job_id = "job-1"
+        client.load_table_from_file.return_value = load_job
+        monkeypatch.setattr(snap, "_make_bq_client", lambda *a, **kw: client)
+        return client
+
+    def test_first_file_truncates_subsequent_files_append(self, monkeypatch, tmp_path):
+        from google.cloud import bigquery
+
+        client = self._setup_client(monkeypatch)
+        ns = snap.NAMESPACES[0]
+
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "a.ndjson": json.dumps(
+                    {
+                        "name": "Mainz",
+                        "identifier": 1,
+                        "article_body": {"html": "<p>x</p>"},
+                    }
+                )
+                + "\n",
+                "b.ndjson": json.dumps(
+                    {
+                        "name": "Berlin",
+                        "identifier": 2,
+                        "article_body": {"html": "<p>y</p>"},
+                    }
+                )
+                + "\n",
+                "c.ndjson": json.dumps(
+                    {
+                        "name": "Hamburg",
+                        "identifier": 3,
+                        "article_body": {"html": "<p>z</p>"},
+                    }
+                )
+                + "\n",
+            },
+        )
+
+        snap.load_tarball_to_bigquery(
+            tarball,
+            project="proj",
+            dataset="ds",
+            ns=ns,
+            credentials_path=None,
+        )
+
+        assert client.load_table_from_file.call_count == 3
+        dispositions = [
+            call.kwargs["job_config"].write_disposition
+            for call in client.load_table_from_file.call_args_list
+        ]
+        assert dispositions == [
+            bigquery.WriteDisposition.WRITE_TRUNCATE,
+            bigquery.WriteDisposition.WRITE_APPEND,
+            bigquery.WriteDisposition.WRITE_APPEND,
+        ]
+
+    def test_extracted_files_are_gone_after_load(self, monkeypatch, tmp_path):
+        # The whole point of the iter-extract design: at the end of the run
+        # there must be no extracted NDJSON files lingering on disk.
+        self._setup_client(monkeypatch)
+        ns = snap.NAMESPACES[0]
+
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "a.ndjson": json.dumps({"name": "X", "article_body": {"html": "<p>x</p>"}}) + "\n",
+                "b.ndjson": json.dumps({"name": "Y", "article_body": {"html": "<p>y</p>"}}) + "\n",
+            },
+        )
+
+        snap.load_tarball_to_bigquery(
+            tarball,
+            project="proj",
+            dataset="ds",
+            ns=ns,
+            credentials_path=None,
+        )
+
+        # Tarball stays (caller decides whether to keep it); extracted
+        # NDJSON files should all be gone.
+        assert tarball.exists()
+        leftover = list(tmp_path.glob("*.ndjson"))
+        assert leftover == [], f"Expected no leftover NDJSON, got {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# load_tarball_to_bigquery: streaming-insert dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTarballStreaming:
+    def test_truncates_externally_managed_table_before_streaming(self, monkeypatch, tmp_path):
+        # Streaming inserts append; without a TRUNCATE we'd silently double
+        # the table on each run for Pulumi-managed tables.
+        client = MagicMock()
+        client.insert_rows_json.return_value = []
+        monkeypatch.setattr(snap, "_make_bq_client", lambda *a, **kw: client)
+
+        ns = snap.NAMESPACES[0]
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "a.ndjson": json.dumps(
+                    {
+                        "name": "Mainz",
+                        "identifier": 1,
+                        "article_body": {"html": "<p>x</p>"},
+                    }
+                )
+                + "\n"
+            },
+        )
+
+        snap.load_tarball_to_bigquery(
+            tarball,
+            project="proj",
+            dataset="ds",
+            ns=ns,
+            credentials_path=None,
+            use_streaming_insert=True,
+        )
+
+        truncate_calls = [
+            call for call in client.query.call_args_list if "TRUNCATE TABLE" in call.args[0]
+        ]
+        assert len(truncate_calls) == 1
+
+    def test_does_not_truncate_when_script_recreates_table(self, monkeypatch, tmp_path):
+        # NS6 path drops + recreates the table, so an explicit TRUNCATE
+        # would be redundant work.
+        client = MagicMock()
+        client.insert_rows_json.return_value = []
+        monkeypatch.setattr(snap, "_make_bq_client", lambda *a, **kw: client)
+
+        ns = snap.NAMESPACES[6]
+        tarball = _make_tarball(
+            tmp_path,
+            {"a.ndjson": json.dumps({"name": "File:x.jpg", "identifier": 1}) + "\n"},
+        )
+
+        snap.load_tarball_to_bigquery(
+            tarball,
+            project="proj",
+            dataset="ds",
+            ns=ns,
+            credentials_path=None,
+            use_streaming_insert=True,
+        )
+
+        truncate_calls = [
+            call for call in client.query.call_args_list if "TRUNCATE TABLE" in call.args[0]
+        ]
+        assert truncate_calls == []

--- a/tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
+++ b/tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
@@ -199,16 +199,35 @@ class TestPrepareTable:
         _, kwargs = client.create_table.call_args
         assert "exists_ok" not in kwargs
 
-    def test_ns0_does_not_drop_the_table(self):
+    def test_ns0_does_not_drop_or_create_the_table(self):
+        """NS0 is externally managed (Pulumi). Script must NOT touch it.
+
+        Bootstrapping the table here would silently drop clustering /
+        deletion-protection settings that Pulumi owns; the next Pulumi
+        run would then see drift. Read-only verification only.
+        """
         client = MagicMock()
         ns = snap.NAMESPACES[0]
         snap._prepare_table(client, "p.d.article_pages", ns)
         client.delete_table.assert_not_called()
-        # exists_ok=True so the call is a no-op when Pulumi has already
-        # provisioned the table (production), and a bootstrap when it hasn't (dev).
-        client.create_table.assert_called_once()
-        _, kwargs = client.create_table.call_args
-        assert kwargs.get("exists_ok") is True
+        client.create_table.assert_not_called()
+        # ``get_table`` is the existence probe — must be called.
+        client.get_table.assert_called_once_with("p.d.article_pages")
+
+    def test_ns0_raises_when_table_missing(self):
+        """Missing externally-managed table fails loudly.
+
+        Operator gets a clear pointer to provision the table via Pulumi
+        instead of the script silently bootstrapping a stripped-down
+        version without clustering / deletion-protection.
+        """
+        client = MagicMock()
+        client.get_table.side_effect = Exception("404 Not found: Table p.d.article_pages")
+        ns = snap.NAMESPACES[0]
+
+        with pytest.raises(RuntimeError, match="externally managed"):
+            snap._prepare_table(client, "p.d.article_pages", ns)
+        client.create_table.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +404,33 @@ class TestIterExtractNdjson:
         with pytest.raises(ValueError, match="No .ndjson files found"):
             next(it)
 
+    def test_extracts_into_private_tempdir_not_parent(self, tmp_path):
+        """Tar members extract under a private temp dir, never the parent.
+
+        Without an isolated extract dir, ``existing.ndjson`` in the
+        tarball would land at ``tmp_path/existing.ndjson`` (which we
+        seeded ourselves) and our cleanup ``unlink`` would then delete
+        the operator's pre-existing file.
+        """
+        sibling = tmp_path / "existing.ndjson"
+        sibling.write_text("DO NOT TOUCH\n")
+
+        tarball = _make_tarball(tmp_path, {"existing.ndjson": '{"x": 1}\n'})
+
+        # Drain the iterator — the .ndjson member is yielded, then the
+        # iterator's finally block cleans it up.
+        list(snap.iter_extract_ndjson(tarball))
+
+        # The seeded sibling is untouched.
+        assert sibling.exists()
+        assert sibling.read_text() == "DO NOT TOUCH\n"
+
+        # And the temp dir is gone after iteration finishes.
+        leftover_dirs = [
+            p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("wme-ndjson-")
+        ]
+        assert leftover_dirs == []
+
 
 # ---------------------------------------------------------------------------
 # load_tarball_to_bigquery: end-to-end load-job dispatch
@@ -464,6 +510,52 @@ class TestLoadTarballLoadJob:
             bigquery.WriteDisposition.WRITE_APPEND,
             bigquery.WriteDisposition.WRITE_APPEND,
         ]
+
+    def test_rejects_malicious_project_identifier(self, monkeypatch, tmp_path):
+        """Bad project identifiers raise before any SQL is built.
+
+        ``project`` / ``dataset`` get interpolated into the raw SQL
+        ``TRUNCATE TABLE`` statement on the streaming-insert path —
+        a backtick or whitespace there would close ``table_ref`` early.
+        """
+        self._setup_client(monkeypatch)
+        ns = snap.NAMESPACES[0]
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "a.ndjson": json.dumps({"name": "Mainz", "article_body": {"html": "<p>x</p>"}})
+                + "\n"
+            },
+        )
+
+        with pytest.raises(ValueError, match="Invalid BigQuery project"):
+            snap.load_tarball_to_bigquery(
+                tarball,
+                project="evil`; DROP TABLE x; --",
+                dataset="ds",
+                ns=ns,
+                credentials_path=None,
+            )
+
+    def test_rejects_malicious_dataset_identifier(self, monkeypatch, tmp_path):
+        self._setup_client(monkeypatch)
+        ns = snap.NAMESPACES[0]
+        tarball = _make_tarball(
+            tmp_path,
+            {
+                "a.ndjson": json.dumps({"name": "Mainz", "article_body": {"html": "<p>x</p>"}})
+                + "\n"
+            },
+        )
+
+        with pytest.raises(ValueError, match="Invalid BigQuery dataset"):
+            snap.load_tarball_to_bigquery(
+                tarball,
+                project="proj",
+                dataset="ds with space",
+                ns=ns,
+                credentials_path=None,
+            )
 
     def test_extracted_files_are_gone_after_load(self, monkeypatch, tmp_path):
         # The whole point of the iter-extract design: at the end of the run

--- a/tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
+++ b/tests/mwlib/apps/test_fetch_wikimedia_snapshot.py
@@ -1,0 +1,96 @@
+"""Targeted tests for ``fetch_wikimedia_snapshot``.
+
+Focused on the security-sensitive tar extraction path. The full ingestion
+path (download, BigQuery load) is exercised by ops runs rather than unit
+tests because it requires WME credentials and a real BigQuery target.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+
+import pytest
+
+from mwlib.apps.fetch_wikimedia_snapshot import extract_ndjson_from_tarball
+
+
+def _add_regular_file(tar, name, content):
+    info = tarfile.TarInfo(name=name)
+    data = content.encode("utf-8")
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _add_symlink(tar, name, target):
+    info = tarfile.TarInfo(name=name)
+    info.type = tarfile.SYMTYPE
+    info.linkname = target
+    tar.addfile(info)
+
+
+def _add_hardlink(tar, name, target):
+    info = tarfile.TarInfo(name=name)
+    info.type = tarfile.LNKTYPE
+    info.linkname = target
+    tar.addfile(info)
+
+
+class TestExtractNdjsonFromTarball:
+    def test_extracts_regular_ndjson_files(self, tmp_path):
+        tarball = tmp_path / "snap.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _add_regular_file(tar, "a.ndjson", '{"x": 1}\n')
+            _add_regular_file(tar, "b.ndjson", '{"x": 2}\n')
+
+        paths = extract_ndjson_from_tarball(tarball)
+
+        assert sorted(p.name for p in paths) == ["a.ndjson", "b.ndjson"]
+        assert all(p.read_text().strip() for p in paths)
+
+    def test_rejects_path_traversal(self, tmp_path):
+        tarball = tmp_path / "snap.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _add_regular_file(tar, "../escape.ndjson", "x\n")
+
+        with pytest.raises(ValueError, match="Suspicious tar member path"):
+            extract_ndjson_from_tarball(tarball)
+
+    def test_rejects_absolute_path(self, tmp_path):
+        tarball = tmp_path / "snap.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _add_regular_file(tar, "/etc/passwd.ndjson", "x\n")
+
+        with pytest.raises(ValueError, match="Suspicious tar member path"):
+            extract_ndjson_from_tarball(tarball)
+
+    def test_rejects_symlink_member(self, tmp_path):
+        """A crafted tarball must not be able to write *through* a symlink.
+
+        Symlinks ending in ``.ndjson`` would otherwise be passed to
+        ``tar.extract``, which happily creates the symlink and then a
+        subsequent extracted file written to that name follows it out
+        of the target directory.
+        """
+        tarball = tmp_path / "snap.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _add_symlink(tar, "evil.ndjson", "/tmp/evil-target")
+
+        with pytest.raises(ValueError, match="non-regular tar member"):
+            extract_ndjson_from_tarball(tarball)
+
+    def test_rejects_hardlink_member(self, tmp_path):
+        tarball = tmp_path / "snap.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _add_hardlink(tar, "evil.ndjson", "../something")
+
+        with pytest.raises(ValueError, match="non-regular tar member"):
+            extract_ndjson_from_tarball(tarball)
+
+    def test_no_ndjson_raises(self, tmp_path):
+        tarball = tmp_path / "snap.tar.gz"
+        with tarfile.open(tarball, "w:gz") as tar:
+            _add_regular_file(tar, "README.md", "x\n")
+
+        with pytest.raises(ValueError, match="No .ndjson files"):
+            extract_ndjson_from_tarball(tarball)

--- a/tests/mwlib/network/test_bigquery_lookup.py
+++ b/tests/mwlib/network/test_bigquery_lookup.py
@@ -1,0 +1,398 @@
+"""Unit tests for mwlib.network.bigquery_lookup module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class FakeConf:
+    """Minimal conf stub for testing BigQueryImageLookup."""
+
+    def __init__(self, overrides=None):
+        self._data = {
+            ("bigquery", "project"): "test-project",
+            ("bigquery", "dataset"): "wme_snapshots",
+            ("bigquery", "table"): "file_pages",
+            ("bigquery", "timeout"): "30",
+            ("bigquery", "domains"): "en.wikipedia.org",
+        }
+        if overrides:
+            self._data.update(overrides)
+
+    def get(self, section, option, fallback=None, type_=str):
+        val = self._data.get((section, option), fallback)
+        if type_ is int and val is not None:
+            return int(val)
+        return val
+
+
+class TestBigQueryImageLookup:
+    """Tests for the BigQueryImageLookup class."""
+
+    @patch("mwlib.network.bigquery_lookup.BigQueryImageLookup._init_client")
+    def _make_lookup(self, mock_init, conf=None, client=None):
+        from mwlib.network.bigquery_lookup import BigQueryImageLookup
+
+        mock_init.return_value = None
+        lookup = BigQueryImageLookup(conf=conf or FakeConf())
+        lookup._client = client
+        return lookup
+
+    def test_is_available_with_client(self):
+        lookup = self._make_lookup(client=MagicMock())
+        assert lookup.is_available is True
+
+    def test_is_available_without_client(self):
+        lookup = self._make_lookup(client=None)
+        assert lookup.is_available is False
+
+    def test_handles_domain_match(self):
+        lookup = self._make_lookup(client=MagicMock())
+        assert lookup.handles_domain("https://en.wikipedia.org/wiki/File:Test.jpg") is True
+
+    def test_handles_domain_no_match(self):
+        lookup = self._make_lookup(client=MagicMock())
+        assert lookup.handles_domain("https://commons.wikimedia.org/wiki/File:Test.jpg") is False
+
+    def test_handles_domain_multiple_domains(self):
+        conf = FakeConf({("bigquery", "domains"): "en.wikipedia.org, de.wikipedia.org"})
+        lookup = self._make_lookup(conf=conf, client=MagicMock())
+        assert lookup.handles_domain("https://de.wikipedia.org/wiki/File:Test.jpg") is True
+        assert lookup.handles_domain("https://fr.wikipedia.org/wiki/File:Test.jpg") is False
+
+    def test_fetch_batch_empty_titles(self):
+        lookup = self._make_lookup(client=MagicMock())
+        rows, missing = lookup.fetch_batch([])
+        assert rows == []
+        assert missing == []
+
+    def test_fetch_batch_no_client(self):
+        lookup = self._make_lookup(client=None)
+        titles = ["File:A.jpg", "File:B.jpg"]
+        rows, missing = lookup.fetch_batch(titles)
+        assert rows == []
+        assert missing == titles
+
+    def test_fetch_batch_all_found(self):
+        lookup = self._make_lookup(client=MagicMock())
+
+        mock_rows = [
+            {"name": "File:A.jpg", "templates": ["cc-by-sa"], "image_width": 800, "image_height": 600},
+            {"name": "File:B.jpg", "templates": ["pd-old"], "image_width": 1024, "image_height": 768},
+        ]
+        with patch.object(lookup, "_execute_query", return_value=(mock_rows, [])):
+            rows, missing = lookup.fetch_batch(["File:A.jpg", "File:B.jpg"])
+        assert len(rows) == 2
+        assert missing == []
+        assert rows[0]["name"] == "File:A.jpg"
+        assert rows[1]["name"] == "File:B.jpg"
+
+    def test_fetch_batch_partial_results(self):
+        lookup = self._make_lookup(client=MagicMock())
+
+        mock_rows = [{"name": "File:A.jpg", "templates": ["cc-by-sa"]}]
+        with patch.object(lookup, "_execute_query", return_value=(mock_rows, ["File:B.jpg"])):
+            rows, missing = lookup.fetch_batch(["File:A.jpg", "File:B.jpg"])
+        assert len(rows) == 1
+        assert missing == ["File:B.jpg"]
+
+    def test_fetch_batch_none_found(self):
+        lookup = self._make_lookup(client=MagicMock())
+
+        with patch.object(lookup, "_execute_query", return_value=([], ["File:A.jpg", "File:B.jpg"])):
+            rows, missing = lookup.fetch_batch(["File:A.jpg", "File:B.jpg"])
+        assert rows == []
+        assert missing == ["File:A.jpg", "File:B.jpg"]
+
+    def test_fetch_batch_error_graceful_fallback(self):
+        lookup = self._make_lookup(client=MagicMock())
+
+        with patch.object(lookup, "_execute_query", side_effect=Exception("BigQuery timeout")):
+            rows, missing = lookup.fetch_batch(["File:A.jpg", "File:B.jpg"])
+        assert rows == []
+        assert missing == ["File:A.jpg", "File:B.jpg"]
+
+    def test_config_values(self):
+        conf = FakeConf({
+            ("bigquery", "project"): "my-project",
+            ("bigquery", "dataset"): "my_dataset",
+            ("bigquery", "table"): "my_table",
+            ("bigquery", "timeout"): "60",
+            ("bigquery", "domains"): "en.wikipedia.org,de.wikipedia.org",
+        })
+        lookup = self._make_lookup(conf=conf, client=MagicMock())
+        assert lookup.project == "my-project"
+        assert lookup.dataset == "my_dataset"
+        assert lookup.table == "my_table"
+        assert lookup.timeout == 60
+        assert lookup.domains == {"en.wikipedia.org", "de.wikipedia.org"}
+
+    def test_execute_query_called_with_titles(self):
+        lookup = self._make_lookup(client=MagicMock())
+
+        with patch.object(lookup, "_execute_query", return_value=([], ["File:Test.jpg"])) as mock_eq:
+            lookup.fetch_batch(["File:Test.jpg"])
+        mock_eq.assert_called_once_with(["File:Test.jpg"])
+
+
+class TestFetcherBigQueryIntegration:
+    """Test BigQuery integration points in the Fetcher class."""
+
+    def _make_fetcher_stub(self, filter_type="blacklist"):
+        """Create a minimal object with the Fetcher methods under test."""
+        from mwlib.network.fetch import Fetcher
+        from mwlib.rendering.licensechecker import LicenseChecker
+
+        stub = object.__new__(Fetcher)
+        stub.fetch_license_checker = LicenseChecker(image_db=None, filter_type=filter_type)
+        stub.fetch_license_checker.read_licenses_csv()
+        stub.scheduled = set()
+        stub._bq_deferred_downloads = {}
+        stub._bq_pending = []
+        stub._bq_batch_size = 50
+        stub.bq_lookup = MagicMock()
+        stub.bq_lookup.is_available = True
+        stub.fsout = MagicMock()
+        return stub
+
+    def test_check_license_free_passes(self):
+        """Free license templates should pass the blacklist filter."""
+        stub = self._make_fetcher_stub(filter_type="blacklist")
+        assert stub._check_license_from_templates("File:X.jpg", ["cc-by-sa"]) is True
+
+    def test_check_license_nonfree_blocked_by_blacklist(self):
+        """Nonfree templates should be blocked by blacklist filter."""
+        stub = self._make_fetcher_stub(filter_type="blacklist")
+        assert stub._check_license_from_templates("File:X.jpg", ["non-free logo"]) is False
+
+    def test_check_license_unknown_passes_blacklist(self):
+        """Unknown templates should pass blacklist filter."""
+        stub = self._make_fetcher_stub(filter_type="blacklist")
+        assert stub._check_license_from_templates("File:X.jpg", ["some-unknown-xyz"]) is True
+
+    def test_check_license_unknown_blocked_by_whitelist(self):
+        """Unknown templates should be blocked by whitelist filter."""
+        stub = self._make_fetcher_stub(filter_type="whitelist")
+        assert stub._check_license_from_templates("File:X.jpg", ["some-unknown-xyz"]) is False
+
+    def test_check_license_no_checker(self):
+        """Without a license checker, all images pass."""
+        stub = self._make_fetcher_stub()
+        stub.fetch_license_checker = None
+        assert stub._check_license_from_templates("File:X.jpg", ["non-free logo"]) is True
+
+    def test_store_bq_result_writes_templates(self):
+        """_store_bq_result should write templates to templates.db."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+
+        row = {
+            "name": "File:X.jpg",
+            "templates": ["cc-by-sa", "information"],
+            "image_content_url": "https://upload.wikimedia.org/X.jpg",
+            "image_width": 800,
+            "image_height": 600,
+            "url": "https://en.wikipedia.org/wiki/File:X.jpg",
+        }
+        result = stub._store_bq_result(row)
+
+        assert result is True  # cc-by-sa is free
+        stub.fsout.set_db_key.assert_any_call("templates", "File:X.jpg", ["cc-by-sa", "information"])
+
+    def test_store_bq_result_supplements_imageinfo(self):
+        """_store_bq_result should supplement imageinfo with BQ data."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+
+        row = {
+            "name": "File:X.jpg",
+            "templates": [],
+            "image_content_url": "https://upload.wikimedia.org/X.jpg",
+            "image_width": 800,
+            "image_height": 600,
+            "url": "https://en.wikipedia.org/wiki/File:X.jpg",
+        }
+        stub._store_bq_result(row)
+
+        # Check that imageinfo was written with supplemented data
+        calls = stub.fsout.set_db_key.call_args_list
+        imageinfo_calls = [c for c in calls if c[0][0] == "imageinfo"]
+        assert len(imageinfo_calls) == 1
+        written = imageinfo_calls[0][0][2]
+        assert written["url"] == "https://upload.wikimedia.org/X.jpg"
+        assert written["width"] == 800
+        assert written["height"] == 600
+        assert written["descriptionurl"] == "https://en.wikipedia.org/wiki/File:X.jpg"
+
+    def test_store_bq_result_nonfree_returns_false(self):
+        """_store_bq_result should return False for nonfree images."""
+        stub = self._make_fetcher_stub(filter_type="blacklist")
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+
+        row = {"name": "File:X.jpg", "templates": ["non-free logo"]}
+        assert stub._store_bq_result(row) is False
+
+    def test_flush_bq_batch_schedules_free_downloads(self):
+        """_flush_bq_batch should schedule downloads for free-licensed images."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+        stub.schedule_download_image = MagicMock()
+
+        stub._bq_deferred_downloads = {"File:X.jpg": "https://thumb/X.jpg"}
+        stub._bq_pending = [("File:X.jpg", MagicMock(), "File:X.jpg")]
+
+        stub.bq_lookup.fetch_batch.return_value = (
+            [{"name": "File:X.jpg", "templates": ["cc-by-sa"]}],
+            [],
+        )
+        stub._flush_bq_batch()
+
+        stub.schedule_download_image.assert_called_once_with("https://thumb/X.jpg", "File:X.jpg")
+
+    def test_flush_bq_batch_skips_nonfree_downloads(self):
+        """_flush_bq_batch should skip downloads for nonfree images."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+        stub.schedule_download_image = MagicMock()
+
+        stub._bq_deferred_downloads = {"File:X.jpg": "https://thumb/X.jpg"}
+        stub._bq_pending = [("File:X.jpg", MagicMock(), "File:X.jpg")]
+
+        stub.bq_lookup.fetch_batch.return_value = (
+            [{"name": "File:X.jpg", "templates": ["non-free logo"]}],
+            [],
+        )
+        stub._flush_bq_batch()
+
+        stub.schedule_download_image.assert_not_called()
+        assert "File:X.jpg" not in stub._bq_deferred_downloads
+
+    def test_flush_bq_batch_fallback_for_missing(self):
+        """_flush_bq_batch should fall back to remote API for missing titles."""
+        from mwlib.network.fetch import Fetcher
+
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+        stub.schedule_download_image = MagicMock()
+        stub._refcall = MagicMock()
+
+        mock_api = MagicMock()
+        mock_api.api_request_limit = 50
+        stub._bq_deferred_downloads = {"File:X.jpg": "https://thumb/X.jpg"}
+        stub._bq_pending = [("File:X.jpg", mock_api, "File:X.jpg")]
+
+        stub.bq_lookup.fetch_batch.return_value = ([], ["File:X.jpg"])
+        stub._flush_bq_batch()
+
+        # Should call fetch_image_page via _refcall for missing titles
+        stub._refcall.assert_called()
+        # Should schedule deferred download for fallback title
+        stub.schedule_download_image.assert_called_once_with("https://thumb/X.jpg", "File:X.jpg")
+
+    def test_flush_bq_batch_title_mapping(self):
+        """_flush_bq_batch should map local names back to original titles for deferred downloads."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+        stub.schedule_download_image = MagicMock()
+
+        # Simulate namespace conversion: original "File:X.jpg" → local "Datei:X.jpg"
+        stub._bq_deferred_downloads = {"File:X.jpg": "https://thumb/X.jpg"}
+        stub._bq_pending = [("Datei:X.jpg", MagicMock(), "File:X.jpg")]
+
+        stub.bq_lookup.fetch_batch.return_value = (
+            [{"name": "Datei:X.jpg", "templates": ["cc-by-sa"]}],
+            [],
+        )
+        stub._flush_bq_batch()
+
+        # Download should be scheduled using original title
+        stub.schedule_download_image.assert_called_once_with("https://thumb/X.jpg", "File:X.jpg")
+
+    def test_flush_bq_batch_deduplicates_titles(self):
+        """_flush_bq_batch should deduplicate titles before querying BigQuery."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+        stub.schedule_download_image = MagicMock()
+
+        mock_api = MagicMock()
+        # Same title appears twice
+        stub._bq_pending = [
+            ("File:X.jpg", mock_api, "File:X.jpg"),
+            ("File:X.jpg", mock_api, "File:X.jpg"),
+        ]
+
+        stub.bq_lookup.fetch_batch.return_value = (
+            [{"name": "File:X.jpg", "templates": ["cc-by-sa"]}],
+            [],
+        )
+        stub._flush_bq_batch()
+
+        # Should only query once for the deduplicated title
+        call_args = stub.bq_lookup.fetch_batch.call_args[0][0]
+        assert call_args == ["File:X.jpg"]
+
+
+class TestNuWikiTemplatesDb:
+    """Test templates.db shortcircuit in NuWiki."""
+
+    def _make_nuwiki_dir(self, tmp_path, with_templates_db=True, templates_data=None):
+        """Create a minimal nuwiki directory for testing."""
+        import json as stdlib_json
+
+        from sqlitedict import SqliteDict
+
+        nuwiki_path = tmp_path / "nuwiki"
+        nuwiki_path.mkdir()
+        (nuwiki_path / "revisions-1.txt").write_text("")
+        siteinfo = {
+            "namespaces": {
+                "6": {"id": 6, "*": "File", "canonical": "File"},
+                "0": {"id": 0, "*": "", "content": ""},
+            },
+            "general": {"lang": "en"},
+        }
+        (nuwiki_path / "siteinfo.json").write_text(stdlib_json.dumps(siteinfo))
+        (nuwiki_path / "imageinfo.db").touch()
+
+        if with_templates_db:
+            db = SqliteDict(str(nuwiki_path / "templates.db"), autocommit=True)
+            if templates_data:
+                for title, templates in templates_data.items():
+                    db[title] = stdlib_json.dumps(templates)
+            db.close()
+
+        return str(nuwiki_path)
+
+    def test_get_image_templates_and_args_from_templates_db(self, tmp_path):
+        """Should return templates from templates.db when available."""
+        from mwlib.core.nuwiki import Adapt
+
+        path = self._make_nuwiki_dir(
+            tmp_path,
+            templates_data={"File:Test.jpg": ["cc-by-sa", "information"]},
+        )
+        adapt = Adapt(path)
+
+        result = adapt.get_image_templates_and_args("File:Test.jpg")
+        assert result == {"cc-by-sa", "information"}
+
+    def test_get_image_templates_and_args_falls_back_without_entry(self, tmp_path):
+        """Should fall back to wikitext parsing when templates.db has no entry."""
+        from mwlib.core.nuwiki import Adapt
+
+        path = self._make_nuwiki_dir(tmp_path, with_templates_db=True)
+        adapt = Adapt(path)
+
+        # No templates.db entry, no description page → should return empty
+        result = adapt.get_image_templates_and_args("File:Missing.jpg")
+        assert result == []
+
+    def test_get_image_templates_and_args_no_templates_db(self, tmp_path):
+        """Should fall back to wikitext parsing when templates.db doesn't exist."""
+        from mwlib.core.nuwiki import Adapt
+
+        path = self._make_nuwiki_dir(tmp_path, with_templates_db=False)
+        adapt = Adapt(path)
+
+        result = adapt.get_image_templates_and_args("File:Missing.jpg")
+        assert result == []

--- a/tests/mwlib/network/test_bigquery_lookup.py
+++ b/tests/mwlib/network/test_bigquery_lookup.py
@@ -370,38 +370,59 @@ class TestFetcherBigQueryIntegration:
         row = {"name": "File:X.jpg", "templates": ["non-free logo"]}
         assert stub._store_bq_result(row) is False
 
-    # ---- Round 2: defensive parsing + empty-list negative cache ----
+    # ---- Round 6: malformed BQ templates fail closed ----
 
-    def test_store_bq_result_handles_malformed_templates_json(self):
-        """A single row's malformed JSON must not abort the whole batch.
+    def test_store_bq_result_raises_on_malformed_templates_json(self):
+        """Unparsable templates JSON must NOT be treated as 'no templates'.
 
-        BigQuery JSON columns can hand back a string we then ``json.loads``.
-        If the string is malformed, this used to raise inside the batch
-        flush after BigQuery had already succeeded — bypassing the
-        per-title remote-API fallback for every other row in the batch.
-        Now we treat malformed values as empty and let the normal flow
-        continue.
+        An empty templates list passes ``blacklist`` mode, so silently
+        treating corrupt data as empty would fail open and let through
+        images the remote description-page parser may have rejected.
+        Instead the row raises ``BqTemplatesError`` and the flush loop
+        reroutes the title to the remote-API fallback.
         """
-        stub = self._make_fetcher_stub()
-        stub.fsout.get_db_key.side_effect = KeyError("not found")
+        from mwlib.network.fetch import BqTemplatesError
 
+        stub = self._make_fetcher_stub()
         row = {"name": "File:X.jpg", "templates": "not-valid-json{"}
-        result = stub._store_bq_result(row)
 
-        # Returns True (no licenses, blacklist default → include).
-        assert result is True
-        # Still wrote a templates entry (empty list) — see negative-cache test.
-        stub.fsout.set_db_key.assert_any_call("templates", "File:X.jpg", [])
+        with pytest.raises(BqTemplatesError):
+            stub._store_bq_result(row)
 
-    def test_store_bq_result_handles_unexpected_templates_shape(self):
-        """A non-list, non-string templates value is also tolerated."""
+        # Nothing was persisted — the title will be redriven via the
+        # remote API by ``_flush_bq_batch``.
+        stub.fsout.set_db_key.assert_not_called()
+
+    def test_store_bq_result_raises_on_unexpected_templates_shape(self):
+        """A non-list, non-string templates value also fails closed."""
+        from mwlib.network.fetch import BqTemplatesError
+
         stub = self._make_fetcher_stub()
-        stub.fsout.get_db_key.side_effect = KeyError("not found")
-
         row = {"name": "File:X.jpg", "templates": {"unexpected": "shape"}}
-        # Must not raise.
-        stub._store_bq_result(row)
-        stub.fsout.set_db_key.assert_any_call("templates", "File:X.jpg", [])
+
+        with pytest.raises(BqTemplatesError):
+            stub._store_bq_result(row)
+        stub.fsout.set_db_key.assert_not_called()
+
+    def test_flush_bq_batch_reroutes_corrupt_row_to_fallback(self, monkeypatch):
+        """Corrupt BQ rows are added to ``missing`` so the remote API runs."""
+        stub = self._make_fetcher_stub()
+        stub.schedule_download_image = MagicMock()
+        stub._refcall = MagicMock()
+
+        api = MagicMock()
+        api.api_request_limit = 50
+        stub._bq_pending = [("File:X.jpg", api, "File:X.jpg")]
+        stub.bq_lookup.fetch_batch.return_value = (
+            [{"name": "File:X.jpg", "templates": "not-valid-json{"}],
+            [],
+        )
+
+        stub._flush_bq_batch()
+
+        # Corrupt row routed to fetch_image_page via the missing-fallback path.
+        called_funcs = {call.args[0] for call in stub._refcall.call_args_list}
+        assert stub.fetch_image_page in called_funcs
 
     def test_store_bq_result_writes_empty_list_as_negative_cache(self):
         """An empty templates list is stored, not skipped.
@@ -601,3 +622,43 @@ class TestNuWikiTemplatesDb:
 
         result = adapt.get_image_templates_and_args("File:Missing.jpg")
         assert result == []
+
+    def test_get_contributors_falls_back_to_authors_db_for_bq_images(self, tmp_path):
+        """BigQuery-backed images read attribution from authors.db.
+
+        These images have no description page on disk because the
+        BigQuery shortcut skips ``fetch_image_page``. ``get_image_edits``
+        still populates ``authors.db`` via the remote contributor lookup;
+        this fallback wires the two together so the rendered book isn't
+        attribution-empty.
+        """
+        import json as stdlib_json
+
+        from sqlitedict import SqliteDict
+
+        from mwlib.core.nuwiki import Adapt
+
+        path = self._make_nuwiki_dir(tmp_path)
+        # Seed authors.db as if Fetcher.get_image_edits had run.
+        authors_db = SqliteDict(str(tmp_path / "nuwiki" / "authors.db"), autocommit=True)
+        authors_db["File:BQOnly.jpg"] = stdlib_json.dumps(["Alice", "Bob"])
+        authors_db.close()
+
+        adapt = Adapt(path)
+        # No description page exists for this image (BQ shortcircuit)…
+        assert adapt.get_image_description_page("File:BQOnly.jpg") is None
+        # …but contributors are read from authors.db rather than [] returned.
+        assert adapt.get_contributors("File:BQOnly.jpg") == ["Alice", "Bob"]
+
+    def test_get_contributors_returns_empty_when_no_authors_either(self, tmp_path):
+        """Empty list when neither description page nor authors.db has data.
+
+        Belt-and-braces — the fallback returns ``[]`` instead of raising
+        for images we genuinely have no attribution for.
+        """
+        from mwlib.core.nuwiki import Adapt
+
+        path = self._make_nuwiki_dir(tmp_path)
+        adapt = Adapt(path)
+
+        assert adapt.get_contributors("File:Missing.jpg") == []

--- a/tests/mwlib/network/test_bigquery_lookup.py
+++ b/tests/mwlib/network/test_bigquery_lookup.py
@@ -519,6 +519,33 @@ class TestFetcherBigQueryIntegration:
         # And the deferred entry was dropped.
         assert "File:X.jpg" not in stub._bq_deferred_downloads
 
+    def test_flush_bq_batch_skips_download_when_no_api_for_bq_hit(self):
+        """No API + BQ hit → drop the deferred download too.
+
+        We have license-template data from BigQuery, but
+        ``handle_new_basepath`` skipped ``get_image_edits`` because
+        remote-API discovery failed. Downloading the image would
+        produce a rendered book with no contributor attribution, so
+        we fail closed even though the license check would have
+        passed.
+        """
+        stub = self._make_fetcher_stub()
+        stub.schedule_download_image = MagicMock()
+
+        stub._bq_pending = [("File:X.jpg", None, "File:X.jpg")]
+        stub._bq_deferred_downloads = {"File:X.jpg": "https://thumb/X.jpg"}
+        # BigQuery has the row with a free license — license check
+        # would pass, but we should still refuse to download.
+        stub.bq_lookup.fetch_batch.return_value = (
+            [{"name": "File:X.jpg", "templates": [{"name": "Template:Cc-by-sa"}]}],
+            [],
+        )
+
+        stub._flush_bq_batch()
+
+        stub.schedule_download_image.assert_not_called()
+        assert "File:X.jpg" not in stub._bq_deferred_downloads
+
     def test_flush_bq_batch_reroutes_corrupt_row_to_fallback(self, monkeypatch):
         """Corrupt BQ rows are added to ``missing`` so the remote API runs."""
         stub = self._make_fetcher_stub()

--- a/tests/mwlib/network/test_bigquery_lookup.py
+++ b/tests/mwlib/network/test_bigquery_lookup.py
@@ -163,6 +163,21 @@ class TestBigQueryImageLookup:
         assert rows == []
         assert missing == ["File:A.jpg", "File:B.jpg"]
 
+    def test_fetch_batch_propagates_value_error(self):
+        """Identifier-validation failures must propagate, not get swallowed.
+
+        ``_validate_bigquery_identifier`` raises ``ValueError`` for bad
+        project/dataset/table config. Falling that back to "ordinary
+        BigQuery outage" would hide a deployment or security problem.
+        """
+        lookup = self._make_lookup(client=MagicMock())
+
+        with (
+            patch.object(lookup, "_execute_query", side_effect=ValueError("bad identifier")),
+            pytest.raises(ValueError, match="bad identifier"),
+        ):
+            lookup.fetch_batch(["File:A.jpg"])
+
     def test_config_values(self):
         conf = FakeConf(
             {
@@ -317,6 +332,51 @@ class TestFetcherBigQueryIntegration:
         stub.fetch_license_checker = None
         assert stub._check_license_from_templates(["non-free logo"]) is True
 
+    def test_filter_type_for_apiurl_uses_exact_hostname(self):
+        """``de.wikipedia.org`` → whitelist, anything else → blacklist.
+
+        Done with ``urlparse(...).hostname`` comparison so a lookalike
+        URL can't flip the policy by containing the substring.
+        """
+        from mwlib.network.fetch import Fetcher
+
+        assert Fetcher._filter_type_for_apiurl("https://de.wikipedia.org/w/api.php") == "whitelist"
+        assert Fetcher._filter_type_for_apiurl("https://en.wikipedia.org/w/api.php") == "blacklist"
+        # Lookalike: substring of the netloc but NOT the hostname.
+        assert (
+            Fetcher._filter_type_for_apiurl("https://de.wikipedia.org.evil.example/w/api.php")
+            == "blacklist"
+        )
+        assert (
+            Fetcher._filter_type_for_apiurl("https://evil-de.wikipedia.org/w/api.php")
+            == "blacklist"
+        )
+        # Configured hostname appearing only in the path.
+        assert (
+            Fetcher._filter_type_for_apiurl("https://other.example/de.wikipedia.org/api.php")
+            == "blacklist"
+        )
+
+    def test_license_checker_public_helper_matches_render_policy(self):
+        """Public helper produces the same answers as fetch-time wrapper.
+
+        ``decide_from_template_names`` is the public seam — fetch-time
+        callers go through it instead of poking ``_get_licenses`` from
+        outside the class.
+        """
+        from mwlib.rendering.licensechecker import LicenseChecker
+
+        checker = LicenseChecker(image_db=None, filter_type="blacklist")
+        checker.read_licenses_csv()
+
+        assert checker.decide_from_template_names(["cc-by-sa"]) is True
+        assert checker.decide_from_template_names(["non-free logo"]) is False
+        assert checker.decide_from_template_names(["never-heard-of-this"]) is True
+
+        whitelist = LicenseChecker(image_db=None, filter_type="whitelist")
+        whitelist.read_licenses_csv()
+        assert whitelist.decide_from_template_names(["never-heard-of-this"]) is False
+
     def test_store_bq_result_writes_templates(self):
         """_store_bq_result should write templates to templates.db."""
         stub = self._make_fetcher_stub()
@@ -403,6 +463,61 @@ class TestFetcherBigQueryIntegration:
         with pytest.raises(BqTemplatesError):
             stub._store_bq_result(row)
         stub.fsout.set_db_key.assert_not_called()
+
+    # ---- Round 7: stricter element validation ----
+
+    def test_extract_template_names_rejects_dict_without_name(self):
+        from mwlib.network.fetch import BqTemplatesError, Fetcher
+
+        with pytest.raises(BqTemplatesError):
+            Fetcher._extract_bq_template_names("File:X.jpg", [{"url": "x"}])
+
+    def test_extract_template_names_rejects_dict_with_empty_name(self):
+        from mwlib.network.fetch import BqTemplatesError, Fetcher
+
+        with pytest.raises(BqTemplatesError):
+            Fetcher._extract_bq_template_names("File:X.jpg", [{"name": ""}])
+
+    def test_extract_template_names_rejects_non_dict_non_str_element(self):
+        from mwlib.network.fetch import BqTemplatesError, Fetcher
+
+        with pytest.raises(BqTemplatesError):
+            Fetcher._extract_bq_template_names("File:X.jpg", [["nested-list"]])
+
+    def test_extract_template_names_rejects_empty_string_element(self):
+        from mwlib.network.fetch import BqTemplatesError, Fetcher
+
+        with pytest.raises(BqTemplatesError):
+            Fetcher._extract_bq_template_names("File:X.jpg", [""])
+
+    # ---- Round 7: missing-without-api fails closed ----
+
+    def test_flush_bq_batch_skips_download_when_no_api_for_missing(self):
+        """No API + BQ miss → drop the deferred download.
+
+        Otherwise we'd ship an image with no license/attribution data
+        at all — a fail-open path.
+        """
+        stub = self._make_fetcher_stub()
+        stub.schedule_download_image = MagicMock()
+        stub._refcall = MagicMock()
+
+        # No API attached to the pending entry — the BQ-eligible path
+        # in handle_new_basepath fell through to BQ-only after a failed
+        # remote-API discovery.
+        stub._bq_pending = [("File:X.jpg", None, "File:X.jpg")]
+        stub._bq_deferred_downloads = {"File:X.jpg": "https://thumb/X.jpg"}
+        # BigQuery misses this title.
+        stub.bq_lookup.fetch_batch.return_value = ([], ["File:X.jpg"])
+
+        stub._flush_bq_batch()
+
+        # No image download was scheduled.
+        stub.schedule_download_image.assert_not_called()
+        # No fetch_image_page was scheduled either (no api).
+        stub._refcall.assert_not_called()
+        # And the deferred entry was dropped.
+        assert "File:X.jpg" not in stub._bq_deferred_downloads
 
     def test_flush_bq_batch_reroutes_corrupt_row_to_fallback(self, monkeypatch):
         """Corrupt BQ rows are added to ``missing`` so the remote API runs."""

--- a/tests/mwlib/network/test_bigquery_lookup.py
+++ b/tests/mwlib/network/test_bigquery_lookup.py
@@ -81,6 +81,24 @@ class TestBigQueryImageLookup:
         assert lookup.handles_domain("en.wikipedia.org") is True
         assert lookup.handles_domain("commons.wikimedia.org") is False
 
+    def test_handles_domain_normalizes_uppercase_config(self):
+        """Hostnames are case-insensitive — uppercase config must still match."""
+        conf = FakeConf({("bigquery", "domains"): "EN.Wikipedia.ORG"})
+        lookup = self._make_lookup(conf=conf, client=MagicMock())
+        assert lookup.handles_domain("https://en.wikipedia.org/wiki/File:X.jpg") is True
+        assert lookup.handles_domain("https://EN.WIKIPEDIA.ORG/wiki/File:X.jpg") is True
+
+    def test_handles_domain_strips_port_from_url(self):
+        """``urlparse(...).netloc`` includes the port; ``.hostname`` doesn't.
+
+        Without this fix, the perfectly normal ``https://en.wikipedia.org:443/x``
+        would miss the configured ``en.wikipedia.org`` set.
+        """
+        lookup = self._make_lookup(client=MagicMock())
+        assert lookup.handles_domain("https://en.wikipedia.org:443/wiki/File:X.jpg") is True
+        # Userinfo + port shouldn't fool it either.
+        assert lookup.handles_domain("https://user:pass@en.wikipedia.org:8080/x") is True
+
     def test_fetch_batch_empty_titles(self):
         lookup = self._make_lookup(client=MagicMock())
         rows, missing = lookup.fetch_batch([])
@@ -351,6 +369,73 @@ class TestFetcherBigQueryIntegration:
 
         row = {"name": "File:X.jpg", "templates": ["non-free logo"]}
         assert stub._store_bq_result(row) is False
+
+    # ---- Round 2: defensive parsing + empty-list negative cache ----
+
+    def test_store_bq_result_handles_malformed_templates_json(self):
+        """A single row's malformed JSON must not abort the whole batch.
+
+        BigQuery JSON columns can hand back a string we then ``json.loads``.
+        If the string is malformed, this used to raise inside the batch
+        flush after BigQuery had already succeeded — bypassing the
+        per-title remote-API fallback for every other row in the batch.
+        Now we treat malformed values as empty and let the normal flow
+        continue.
+        """
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+
+        row = {"name": "File:X.jpg", "templates": "not-valid-json{"}
+        result = stub._store_bq_result(row)
+
+        # Returns True (no licenses, blacklist default → include).
+        assert result is True
+        # Still wrote a templates entry (empty list) — see negative-cache test.
+        stub.fsout.set_db_key.assert_any_call("templates", "File:X.jpg", [])
+
+    def test_store_bq_result_handles_unexpected_templates_shape(self):
+        """A non-list, non-string templates value is also tolerated."""
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+
+        row = {"name": "File:X.jpg", "templates": {"unexpected": "shape"}}
+        # Must not raise.
+        stub._store_bq_result(row)
+        stub.fsout.set_db_key.assert_any_call("templates", "File:X.jpg", [])
+
+    def test_store_bq_result_writes_empty_list_as_negative_cache(self):
+        """An empty templates list is stored, not skipped.
+
+        Without this, render-time ``get_image_templates_and_args`` would
+        fall through to wikitext parsing for an image we deliberately
+        decided not to fetch — which is exactly what the BigQuery cache
+        is supposed to avoid.
+        """
+        stub = self._make_fetcher_stub()
+        stub.fsout.get_db_key.side_effect = KeyError("not found")
+
+        row = {"name": "File:NoTemplates.jpg", "templates": []}
+        stub._store_bq_result(row)
+
+        stub.fsout.set_db_key.assert_any_call("templates", "File:NoTemplates.jpg", [])
+
+    def test_extract_bq_template_names_strips_template_prefix(self):
+        from mwlib.network.fetch import Fetcher
+
+        names = Fetcher._extract_bq_template_names(
+            "File:X.jpg",
+            [
+                {"name": "Template:Cc-by-sa", "url": "..."},
+                {"name": "Information"},
+                "raw-string-name",
+            ],
+        )
+        assert names == ["Cc-by-sa", "Information", "raw-string-name"]
+
+    def test_extract_bq_template_names_handles_none(self):
+        from mwlib.network.fetch import Fetcher
+
+        assert Fetcher._extract_bq_template_names("File:X.jpg", None) == []
 
     def test_flush_bq_batch_schedules_free_downloads(self):
         """_flush_bq_batch should schedule downloads for free-licensed images."""

--- a/tests/mwlib/network/test_bigquery_lookup.py
+++ b/tests/mwlib/network/test_bigquery_lookup.py
@@ -60,6 +60,27 @@ class TestBigQueryImageLookup:
         assert lookup.handles_domain("https://de.wikipedia.org/wiki/File:Test.jpg") is True
         assert lookup.handles_domain("https://fr.wikipedia.org/wiki/File:Test.jpg") is False
 
+    def test_handles_domain_rejects_substring_lookalikes(self):
+        """Lookalike hostnames containing the configured domain must not match.
+
+        A naive ``domain in path`` check would accept attacker-controlled
+        hostnames that contain the configured one as a substring, leaking
+        fetches for unrelated wikis through the BigQuery path.
+        """
+        lookup = self._make_lookup(client=MagicMock())
+        # Attacker-controlled subdomain that contains the configured one
+        assert lookup.handles_domain("https://en.wikipedia.org.example.com/path") is False
+        # Hyphen prefix
+        assert lookup.handles_domain("https://evil-en.wikipedia.org/path") is False
+        # Configured host appearing in the path component of an unrelated host
+        assert lookup.handles_domain("https://other.example.com/en.wikipedia.org/x") is False
+
+    def test_handles_domain_accepts_bare_hostname(self):
+        """Callers sometimes pass just a hostname (no scheme); still match."""
+        lookup = self._make_lookup(client=MagicMock())
+        assert lookup.handles_domain("en.wikipedia.org") is True
+        assert lookup.handles_domain("commons.wikimedia.org") is False
+
     def test_fetch_batch_empty_titles(self):
         lookup = self._make_lookup(client=MagicMock())
         rows, missing = lookup.fetch_batch([])
@@ -77,8 +98,18 @@ class TestBigQueryImageLookup:
         lookup = self._make_lookup(client=MagicMock())
 
         mock_rows = [
-            {"name": "File:A.jpg", "templates": ["cc-by-sa"], "image_width": 800, "image_height": 600},
-            {"name": "File:B.jpg", "templates": ["pd-old"], "image_width": 1024, "image_height": 768},
+            {
+                "name": "File:A.jpg",
+                "templates": ["cc-by-sa"],
+                "image_width": 800,
+                "image_height": 600,
+            },
+            {
+                "name": "File:B.jpg",
+                "templates": ["pd-old"],
+                "image_width": 1024,
+                "image_height": 768,
+            },
         ]
         with patch.object(lookup, "_execute_query", return_value=(mock_rows, [])):
             rows, missing = lookup.fetch_batch(["File:A.jpg", "File:B.jpg"])
@@ -99,7 +130,9 @@ class TestBigQueryImageLookup:
     def test_fetch_batch_none_found(self):
         lookup = self._make_lookup(client=MagicMock())
 
-        with patch.object(lookup, "_execute_query", return_value=([], ["File:A.jpg", "File:B.jpg"])):
+        with patch.object(
+            lookup, "_execute_query", return_value=([], ["File:A.jpg", "File:B.jpg"])
+        ):
             rows, missing = lookup.fetch_batch(["File:A.jpg", "File:B.jpg"])
         assert rows == []
         assert missing == ["File:A.jpg", "File:B.jpg"]
@@ -113,13 +146,15 @@ class TestBigQueryImageLookup:
         assert missing == ["File:A.jpg", "File:B.jpg"]
 
     def test_config_values(self):
-        conf = FakeConf({
-            ("bigquery", "project"): "my-project",
-            ("bigquery", "dataset"): "my_dataset",
-            ("bigquery", "table"): "my_table",
-            ("bigquery", "timeout"): "60",
-            ("bigquery", "domains"): "en.wikipedia.org,de.wikipedia.org",
-        })
+        conf = FakeConf(
+            {
+                ("bigquery", "project"): "my-project",
+                ("bigquery", "dataset"): "my_dataset",
+                ("bigquery", "table"): "my_table",
+                ("bigquery", "timeout"): "60",
+                ("bigquery", "domains"): "en.wikipedia.org,de.wikipedia.org",
+            }
+        )
         lookup = self._make_lookup(conf=conf, client=MagicMock())
         assert lookup.project == "my-project"
         assert lookup.dataset == "my_dataset"
@@ -130,9 +165,92 @@ class TestBigQueryImageLookup:
     def test_execute_query_called_with_titles(self):
         lookup = self._make_lookup(client=MagicMock())
 
-        with patch.object(lookup, "_execute_query", return_value=([], ["File:Test.jpg"])) as mock_eq:
+        with patch.object(
+            lookup, "_execute_query", return_value=([], ["File:Test.jpg"])
+        ) as mock_eq:
             lookup.fetch_batch(["File:Test.jpg"])
         mock_eq.assert_called_once_with(["File:Test.jpg"])
+
+    # ---- Identifier validation (Major: SQL identifier injection) ----
+
+    def test_validate_bigquery_identifier_accepts_normal_names(self):
+        from mwlib.network.bigquery_lookup import _validate_bigquery_identifier
+
+        assert _validate_bigquery_identifier("my_dataset", "dataset") == "my_dataset"
+        assert _validate_bigquery_identifier("project-123", "project") == "project-123"
+        assert _validate_bigquery_identifier("file_pages", "table") == "file_pages"
+
+    def test_validate_bigquery_identifier_rejects_injection_attempts(self):
+        from mwlib.network.bigquery_lookup import _validate_bigquery_identifier
+
+        # Backticks would close ``table_ref`` early.
+        with pytest.raises(ValueError):
+            _validate_bigquery_identifier("foo`; DROP TABLE x; --", "table")
+        # Whitespace and SQL keywords mustn't slip through.
+        for bad in (
+            "",
+            " ",
+            "1leading_digit",
+            "with space",
+            "with;semicolon",
+            "with.dot",
+            "back`tick",
+            "quote'inject",
+        ):
+            with pytest.raises(ValueError):
+                _validate_bigquery_identifier(bad, "table")
+
+    def test_execute_query_rejects_invalid_project(self):
+        """A misconfigured project shouldn't be silently interpolated into SQL."""
+        conf = FakeConf({("bigquery", "project"): "evil`; DROP TABLE x; --"})
+        lookup = self._make_lookup(conf=conf, client=MagicMock())
+        with pytest.raises(ValueError):
+            lookup._execute_query(["File:X.jpg"])
+
+    # ---- Row-mismatch handling (Major: deferred-download leak) ----
+
+    def test_execute_query_drops_rows_not_in_request(self):
+        """Rows whose ``name`` wasn't requested are discarded.
+
+        If BigQuery ever returns a normalized name (different casing,
+        different namespace) the requested title is left in ``missing``
+        so the caller falls back to the remote API and any state keyed
+        on the original title stays reachable.
+        """
+        lookup = self._make_lookup(conf=FakeConf(), client=MagicMock())
+
+        # BigQuery returns a row with a normalized (lower-case) name; the
+        # caller asked for the title-cased version.
+        mock_query_job = MagicMock()
+        mock_query_job.result.return_value = [{"name": "File:example.jpg", "templates": []}]
+        lookup._client.query.return_value = mock_query_job
+
+        rows, missing = lookup._execute_query(["File:Example.JPG"])
+
+        assert rows == []  # the normalized row is discarded
+        assert missing == ["File:Example.JPG"]  # original title is missing
+
+    def test_execute_query_returns_only_exact_matches(self):
+        """Exact-match rows pass through; mismatches don't poison the result.
+
+        Mixed input must still surface the legitimate rows while routing
+        the mismatch to the remote-API fallback.
+        """
+        lookup = self._make_lookup(conf=FakeConf(), client=MagicMock())
+
+        mock_query_job = MagicMock()
+        mock_query_job.result.return_value = [
+            {"name": "File:A.jpg", "templates": []},
+            {"name": "File:b.jpg", "templates": []},  # mismatched casing — drop
+            {"name": "File:C.jpg", "templates": []},
+        ]
+        lookup._client.query.return_value = mock_query_job
+
+        requested = ["File:A.jpg", "File:B.jpg", "File:C.jpg"]
+        rows, missing = lookup._execute_query(requested)
+
+        assert {r["name"] for r in rows} == {"File:A.jpg", "File:C.jpg"}
+        assert missing == ["File:B.jpg"]
 
 
 class TestFetcherBigQueryIntegration:
@@ -158,28 +276,28 @@ class TestFetcherBigQueryIntegration:
     def test_check_license_free_passes(self):
         """Free license templates should pass the blacklist filter."""
         stub = self._make_fetcher_stub(filter_type="blacklist")
-        assert stub._check_license_from_templates("File:X.jpg", ["cc-by-sa"]) is True
+        assert stub._check_license_from_templates(["cc-by-sa"]) is True
 
     def test_check_license_nonfree_blocked_by_blacklist(self):
         """Nonfree templates should be blocked by blacklist filter."""
         stub = self._make_fetcher_stub(filter_type="blacklist")
-        assert stub._check_license_from_templates("File:X.jpg", ["non-free logo"]) is False
+        assert stub._check_license_from_templates(["non-free logo"]) is False
 
     def test_check_license_unknown_passes_blacklist(self):
         """Unknown templates should pass blacklist filter."""
         stub = self._make_fetcher_stub(filter_type="blacklist")
-        assert stub._check_license_from_templates("File:X.jpg", ["some-unknown-xyz"]) is True
+        assert stub._check_license_from_templates(["some-unknown-xyz"]) is True
 
     def test_check_license_unknown_blocked_by_whitelist(self):
         """Unknown templates should be blocked by whitelist filter."""
         stub = self._make_fetcher_stub(filter_type="whitelist")
-        assert stub._check_license_from_templates("File:X.jpg", ["some-unknown-xyz"]) is False
+        assert stub._check_license_from_templates(["some-unknown-xyz"]) is False
 
     def test_check_license_no_checker(self):
         """Without a license checker, all images pass."""
         stub = self._make_fetcher_stub()
         stub.fetch_license_checker = None
-        assert stub._check_license_from_templates("File:X.jpg", ["non-free logo"]) is True
+        assert stub._check_license_from_templates(["non-free logo"]) is True
 
     def test_store_bq_result_writes_templates(self):
         """_store_bq_result should write templates to templates.db."""
@@ -197,7 +315,9 @@ class TestFetcherBigQueryIntegration:
         result = stub._store_bq_result(row)
 
         assert result is True  # cc-by-sa is free
-        stub.fsout.set_db_key.assert_any_call("templates", "File:X.jpg", ["cc-by-sa", "information"])
+        stub.fsout.set_db_key.assert_any_call(
+            "templates", "File:X.jpg", ["cc-by-sa", "information"]
+        )
 
     def test_store_bq_result_supplements_imageinfo(self):
         """_store_bq_result should supplement imageinfo with BQ data."""

--- a/tests/mwlib/network/test_fetch.py
+++ b/tests/mwlib/network/test_fetch.py
@@ -79,8 +79,7 @@ class TestFetch:
 
         # Verify that get_client was called with the correct parameters
         mock_instance.get_client.assert_called_once_with(
-            base_url="https://example.com",
-            use_http2=True
+            base_url="https://example.com", use_http2=True
         )
 
         # Verify that the client's stream method was called with the correct parameters
@@ -93,7 +92,9 @@ class TestFetch:
         with open(path, "rb") as f:
             assert f.read() == b"test data"
 
-    def test_download_to_file_http2_disabled(self, mock_http_client_manager, mock_conf, temp_files):
+    def test_download_to_file_http2_disabled(
+        self, mock_http_client_manager, mock_conf, temp_files
+    ):
         """Test download when HTTP/2 is disabled in configuration."""
         _, mock_instance, _, _ = mock_http_client_manager
         path, temp_path = temp_files
@@ -112,11 +113,12 @@ class TestFetch:
 
         # Verify that get_client was called with HTTP/2 disabled
         mock_instance.get_client.assert_called_once_with(
-            base_url="https://example.com",
-            use_http2=False
+            base_url="https://example.com", use_http2=False
         )
 
-    def test_download_to_file_http2_not_supported(self, mock_http_client_manager, mock_conf, temp_files):
+    def test_download_to_file_http2_not_supported(
+        self, mock_http_client_manager, mock_conf, temp_files
+    ):
         """Test download when HTTP/2 is not supported by the server."""
         _, mock_instance, _, _ = mock_http_client_manager
         path, temp_path = temp_files
@@ -132,11 +134,12 @@ class TestFetch:
 
         # Verify that get_client was called with HTTP/2 disabled
         mock_instance.get_client.assert_called_once_with(
-            base_url="https://example.com",
-            use_http2=False
+            base_url="https://example.com", use_http2=False
         )
 
-    def test_download_to_file_auto_detect_disabled(self, mock_http_client_manager, mock_conf, temp_files):
+    def test_download_to_file_auto_detect_disabled(
+        self, mock_http_client_manager, mock_conf, temp_files
+    ):
         """Test download when auto-detect is disabled in configuration."""
         _, mock_instance, _, _ = mock_http_client_manager
         path, temp_path = temp_files
@@ -155,30 +158,31 @@ class TestFetch:
 
         # Verify that get_client was called with HTTP/2 enabled
         mock_instance.get_client.assert_called_once_with(
-            base_url="https://example.com",
-            use_http2=True
+            base_url="https://example.com", use_http2=True
         )
 
-    def test_download_to_file_http_429_retry(self, mock_http_client_manager, mock_conf, temp_files):
+    def test_download_to_file_http_429_retry(
+        self, mock_http_client_manager, mock_conf, temp_files
+    ):
         """Test retry mechanism for HTTP 429 errors."""
         _, _, mock_client, mock_response = mock_http_client_manager
         path, temp_path = temp_files
 
         # Configure the mock to raise a 429 error on first call, then succeed
         http_error = httpx.HTTPStatusError(
-            "429 Too Many Requests",
-            request=MagicMock(),
-            response=MagicMock(status_code=429)
+            "429 Too Many Requests", request=MagicMock(), response=MagicMock(status_code=429)
         )
-        
+
         # Create a side effect that raises an error on first call, then succeeds
         mock_client.stream.side_effect = [
             MagicMock(__enter__=MagicMock(side_effect=http_error)),
-            MagicMock(__enter__=MagicMock(return_value=mock_response))
+            MagicMock(__enter__=MagicMock(return_value=mock_response)),
         ]
 
         # Call the function with retry parameters
-        download_to_file("https://example.com/file.txt", path, temp_path, max_retries=1, initial_delay=0.01)
+        download_to_file(
+            "https://example.com/file.txt", path, temp_path, max_retries=1, initial_delay=0.01
+        )
 
         # Verify that the client's stream method was called twice
         assert mock_client.stream.call_count == 2
@@ -190,9 +194,7 @@ class TestFetch:
 
         # Configure the mock to raise an HTTP error
         http_error = httpx.HTTPStatusError(
-            "404 Not Found",
-            request=MagicMock(),
-            response=MagicMock(status_code=404)
+            "404 Not Found", request=MagicMock(), response=MagicMock(status_code=404)
         )
         mock_client.stream.return_value.__enter__.side_effect = http_error
 
@@ -212,7 +214,9 @@ class TestFetch:
         with pytest.raises(Exception):
             download_to_file("https://example.com/file.txt", path, temp_path)
 
-    def test_download_to_file_applies_rate_limit(self, mock_http_client_manager, mock_conf, temp_files):
+    def test_download_to_file_applies_rate_limit(
+        self, mock_http_client_manager, mock_conf, temp_files
+    ):
         """Download requests should respect configured max_requests_per_second."""
         path, temp_path = temp_files
 
@@ -235,3 +239,128 @@ class TestFetch:
 
             mock_rate_limiter_cls.assert_called_once_with(max_calls=3, period=1.0)
             mock_rate_limiter.acquire.assert_called_once_with()
+
+
+class TestLookupContributors:
+    """Regression tests for the contributor-attribution flow.
+
+    The previous implementation accepted ``title`` but iterated the
+    pending batch instead — combined with the single-title path no
+    longer appending to that batch, every author was silently dropped.
+    """
+
+    def _make_stub(self):
+        from collections import defaultdict
+
+        from mwlib.network.fetch import Fetcher
+
+        stub = object.__new__(Fetcher)
+        stub.titles_pending_contributor_lookup = defaultdict(list)
+        stub.title_mapping = {}
+        stub.fsout = MagicMock()
+        return stub
+
+    def test_single_title_writes_authors(self):
+        stub = self._make_stub()
+        api = MagicMock()
+        inspect = MagicMock()
+        inspect.get_authors.return_value = ["Alice", "Bob"]
+        api.get_contributors.return_value = {"File:X.jpg": inspect}
+
+        stub._lookup_contributors(api, "File:X.jpg")
+
+        api.get_contributors.assert_called_once_with(["File:X.jpg"])
+        stub.fsout.set_db_key.assert_called_once_with("authors", "File:X.jpg", ["Alice", "Bob"])
+        # Single-title path must NOT touch the pending batch.
+        assert stub.titles_pending_contributor_lookup[api] == []
+
+    def test_single_title_uses_title_mapping(self):
+        """Authors are stored under the mapped (local-namespace) title.
+
+        Image titles get rewritten to the local namespace via
+        ``title_mapping``; the contributor lookup must honour that.
+        """
+        stub = self._make_stub()
+        stub.title_mapping["File:X.jpg"] = "Datei:X.jpg"
+        api = MagicMock()
+        inspect = MagicMock()
+        inspect.get_authors.return_value = ["Alice"]
+        api.get_contributors.return_value = {"File:X.jpg": inspect}
+
+        stub._lookup_contributors(api, "File:X.jpg")
+
+        stub.fsout.set_db_key.assert_called_once_with("authors", "Datei:X.jpg", ["Alice"])
+
+    def test_batch_mode_consumes_pending(self):
+        from mwlib.network.fetch import Fetcher  # noqa: F401  (used in stub)
+
+        stub = self._make_stub()
+        api = MagicMock()
+        stub.titles_pending_contributor_lookup[api] = ["File:A.jpg", "File:B.jpg"]
+        inspect_a = MagicMock()
+        inspect_a.get_authors.return_value = ["Alice"]
+        inspect_b = MagicMock()
+        inspect_b.get_authors.return_value = ["Bob"]
+        api.get_contributors.return_value = {
+            "File:A.jpg": inspect_a,
+            "File:B.jpg": inspect_b,
+        }
+
+        stub._lookup_contributors(api)
+
+        api.get_contributors.assert_called_once_with(["File:A.jpg", "File:B.jpg"])
+        # Both titles' authors written
+        keys_written = {
+            (call.args[1], tuple(call.args[2])) for call in stub.fsout.set_db_key.call_args_list
+        }
+        assert ("File:A.jpg", ("Alice",)) in keys_written
+        assert ("File:B.jpg", ("Bob",)) in keys_written
+        # Batch must be cleared so the next call doesn't re-fetch.
+        assert stub.titles_pending_contributor_lookup[api] == []
+
+    def test_redirected_titles_are_skipped(self):
+        """Titles missing from the API response are skipped silently.
+
+        E.g. when the page got redirected away — we don't want to raise
+        or write a partial entry.
+        """
+        stub = self._make_stub()
+        api = MagicMock()
+        api.get_contributors.return_value = {}  # no entry for "File:X.jpg"
+
+        stub._lookup_contributors(api, "File:X.jpg")
+
+        stub.fsout.set_db_key.assert_not_called()
+
+    def test_empty_batch_is_a_noop(self):
+        stub = self._make_stub()
+        api = MagicMock()
+
+        stub._lookup_contributors(api)
+
+        api.get_contributors.assert_not_called()
+        stub.fsout.set_db_key.assert_not_called()
+
+
+class TestFetcherInstanceState:
+    """Per-instance state mustn't leak across Fetcher instances."""
+
+    def test_pending_lookup_is_per_instance(self):
+        from collections import defaultdict
+
+        from mwlib.network.fetch import Fetcher
+
+        a = object.__new__(Fetcher)
+        a.titles_pending_contributor_lookup = defaultdict(list)
+        a.title_mapping = {}
+        b = object.__new__(Fetcher)
+        b.titles_pending_contributor_lookup = defaultdict(list)
+        b.title_mapping = {}
+
+        api = MagicMock()
+        a.titles_pending_contributor_lookup[api].append("only-on-a")
+        a.title_mapping["only-on-a"] = "mapped-a"
+
+        # Instance b must NOT see anything from a.
+        assert b.titles_pending_contributor_lookup[api] == []
+        assert b.title_mapping == {}

--- a/tests/mwlib/network/test_fetch.py
+++ b/tests/mwlib/network/test_fetch.py
@@ -342,6 +342,83 @@ class TestLookupContributors:
         stub.fsout.set_db_key.assert_not_called()
 
 
+class TestFinishDoesNotFlushBQ:
+    """``finish()`` must not run the BigQuery batch flush.
+
+    The flush has been moved into ``run()`` so that the pool can be
+    joined a second time and drain greenlets the flush spawns. If
+    ``finish()`` were still flushing, those greenlets would be scheduled
+    after the last ``pool.join()`` — the original blocker we're
+    guarding against.
+    """
+
+    def test_finish_does_not_call_flush_bq_batch(self):
+        from unittest.mock import MagicMock
+
+        from mwlib.network.fetch import Fetcher
+
+        stub = object.__new__(Fetcher)
+        # Pretend there's a pending batch and a working bq_lookup; if
+        # finish() were still flushing, this would be the trigger.
+        stub.bq_lookup = MagicMock()
+        stub._bq_pending = [("File:X.jpg", MagicMock(), "File:X.jpg")]
+        stub._flush_bq_batch = MagicMock()
+        stub._sanity_check = MagicMock()
+        stub.lookup_contributors_for_remaining_titles = MagicMock()
+        stub.titles_pending_contributor_lookup = {}
+        stub.fsout = MagicMock()
+        stub.redirects = {}
+        stub.licenses = {}
+
+        stub.finish()
+
+        stub._flush_bq_batch.assert_not_called()
+        # The closing side effects we DO expect.
+        stub._sanity_check.assert_called_once()
+        stub.lookup_contributors_for_remaining_titles.assert_called_once()
+        stub.fsout.close.assert_called_once()
+
+
+class TestGetImageEditsOrdering:
+    """``get_image_edits`` must populate ``title_mapping`` before lookup.
+
+    Otherwise authors land under the remote namespace title rather than
+    the local one. The previous round only fixed ``_lookup_contributors``
+    to use the passed title; ``get_image_edits`` still ordered the
+    mapping update *after* the (immediate) contributor lookup.
+    """
+
+    def _make_stub(self):
+        from collections import defaultdict
+        from unittest.mock import MagicMock
+
+        from mwlib.network.fetch import Fetcher
+
+        stub = object.__new__(Fetcher)
+        stub.titles_pending_contributor_lookup = defaultdict(list)
+        stub.title_mapping = {}
+        stub.fsout = MagicMock()
+        # Minimal nshandler that returns the local file namespace name.
+        stub.nshandler = MagicMock()
+        stub.nshandler.get_nsname_by_number.return_value = "Datei"
+        return stub
+
+    def test_authors_stored_under_local_title(self):
+        from unittest.mock import MagicMock
+
+        stub = self._make_stub()
+        api = MagicMock()
+        inspect = MagicMock()
+        inspect.get_authors.return_value = ["Alice"]
+        api.get_contributors.return_value = {"File:X.jpg": inspect}
+
+        stub.get_image_edits("File:X.jpg", api)
+
+        # Mapping must be set; authors written under the local title.
+        assert stub.title_mapping["File:X.jpg"] == "Datei:X.jpg"
+        stub.fsout.set_db_key.assert_called_once_with("authors", "Datei:X.jpg", ["Alice"])
+
+
 class TestFetcherInstanceState:
     """Per-instance state mustn't leak across Fetcher instances."""
 

--- a/tests/mwlib/network/test_http_client.py
+++ b/tests/mwlib/network/test_http_client.py
@@ -176,8 +176,14 @@ class TestHttpClientManager:
         # A standard client should have been created instead
         assert "oauth2=False" in list(http_client_manager._clients.keys())[0]
 
-    def test_create_oauth2_client_with_credentials(self, http_client_manager, mock_conf):
-        """Test that a standard client is created with OAuth2 credentials."""
+    def test_get_client_with_oauth2_credentials_caches_under_oauth2_key(
+        self, http_client_manager, mock_conf
+    ):
+        """OAuth2-enabled clients are cached under an ``oauth2=True`` key.
+
+        Requests for OAuth2 vs standard auth go to different cache
+        entries so callers asking for one don't get the other back.
+        """
         mock_conf.get.side_effect = lambda section, name, default, convert=None: {
             ("oauth2", "client_id"): "client_id",
             ("oauth2", "client_secret"): "client_secret",
@@ -187,10 +193,8 @@ class TestHttpClientManager:
             ("fetch", "max_connections"): 20,
         }.get((section, name), default)
 
-        # Create an OAuth2 client with missing credentials
         http_client_manager.get_client("https://example.com")
 
-        # A standard client should have been created instead
         assert "oauth2=True" in list(http_client_manager._clients.keys())[0]
 
     def test_invalidate_client_removes_cached_instance(self, http_client_manager, mock_conf):
@@ -223,3 +227,145 @@ class TestHttpClientManager:
 
         assert client1 is client2
         assert str(client1.base_url) == "https://example.com"
+
+    def test_oauth2_without_credentials_caches_under_oauth2_false(
+        self, http_client_manager, mock_conf
+    ):
+        """The blocker: OAuth2 fallback must update the cache key.
+
+        Without this, a missing-credentials run would store a *standard*
+        client under ``oauth2=True``, and the next caller asking for
+        OAuth2 would get that standard client back while still treating
+        it as OAuth2 (and try to fetch_token on it).
+        """
+        from httpx import Client as StandardClient
+
+        mock_conf.get.side_effect = lambda section, name, default=None, convert=None: {
+            ("oauth2", "client_id"): "",
+            ("oauth2", "client_secret"): "",
+            ("oauth2", "enabled"): True,
+            ("http2", "enabled"): False,
+            ("http2", "auto_detect"): False,
+            ("fetch", "max_connections"): 20,
+        }.get((section, name), default)
+
+        client = http_client_manager.get_client("https://example.com", use_oauth2=True)
+
+        # The returned client is a plain httpx.Client, NOT an OAuth2Client.
+        assert isinstance(client, StandardClient)
+        # And it's cached under oauth2=False so the next caller (with or
+        # without OAuth2) gets the right thing.
+        keys = list(http_client_manager._clients.keys())
+        assert any("oauth2=False" in k for k in keys)
+        assert not any("oauth2=True" in k for k in keys)
+
+    def test_get_client_uses_lock_for_concurrent_creation(self, http_client_manager, mock_conf):
+        """Concurrent get_client calls produce one cached client, not duplicates.
+
+        Two callers racing on the same cache key must serialize through
+        the lock rather than each constructing a fresh client.
+        """
+        mock_conf.get.side_effect = lambda section, name, default=None, convert=None: {
+            ("oauth2", "enabled"): False,
+            ("http2", "enabled"): False,
+            ("http2", "auto_detect"): False,
+            ("fetch", "max_connections"): 20,
+        }.get((section, name), default)
+
+        # Drive the lock by spinning the cache check ourselves: if the lock
+        # path is correct, only one StandardClient is constructed for the
+        # same cache key even when both threads see an empty cache before
+        # taking the lock.
+        with patch.object(
+            http_client_manager,
+            "create_standard_client",
+            wraps=http_client_manager.create_standard_client,
+        ) as wrapped:
+            c1 = http_client_manager.get_client("https://example.com")
+            c2 = http_client_manager.get_client("https://example.com")
+            assert c1 is c2
+            assert wrapped.call_count == 1
+
+
+class TestEnsureOAuth2Token:
+    """``ensure_oauth2_token`` keeps cached token info and the client in sync.
+
+    The cache lives on ``MwApi._token_info`` (per-domain), while the
+    actual OAuth-bearing token lives on the OAuth2 client itself. Those
+    two pieces of state drift when the client is recreated; this class
+    locks down the reconciliation behaviour.
+    """
+
+    def _domain_cache(self, token=None, *, expires_at=2000):
+        return {
+            "example.com": {
+                "token": token or {"access_token": "abc", "expires_in": 3600},
+                "expires_at": expires_at,
+                "next_retry_at": 0,
+                "retry_delay": 0,
+            }
+        }
+
+    def test_pushes_cached_token_onto_client_with_no_token(self):
+        from mwlib.network.auth import ensure_oauth2_token
+
+        cached = {"access_token": "abc", "expires_in": 3600}
+        token_info_map = self._domain_cache(token=cached)
+        http_client = MagicMock()
+        http_client.token = None  # client got recreated, lost its token
+
+        ensure_oauth2_token(
+            enabled=True,
+            apiurl="https://example.com/w/api.php",
+            token_info_map=token_info_map,
+            http_client=http_client,
+            logger=MagicMock(),
+            current_time_fn=lambda: 1000,  # before expires_at=2000
+        )
+
+        # No refetch — fetch_token must not have been called.
+        http_client.fetch_token.assert_not_called()
+        # The client now carries the cached token.
+        assert http_client.token == cached
+
+    def test_does_not_refetch_when_client_and_cache_agree(self):
+        from mwlib.network.auth import ensure_oauth2_token
+
+        cached = {"access_token": "abc", "expires_in": 3600}
+        token_info_map = self._domain_cache(token=cached)
+        http_client = MagicMock()
+        http_client.token = cached
+
+        ensure_oauth2_token(
+            enabled=True,
+            apiurl="https://example.com/w/api.php",
+            token_info_map=token_info_map,
+            http_client=http_client,
+            logger=MagicMock(),
+            current_time_fn=lambda: 1000,
+        )
+
+        http_client.fetch_token.assert_not_called()
+
+    def test_refetches_when_cache_expired(self):
+        from mwlib.network.auth import ensure_oauth2_token
+
+        token_info_map = self._domain_cache(expires_at=500)  # already expired
+        http_client = MagicMock()
+        http_client.fetch_token.return_value = {
+            "access_token": "fresh",
+            "expires_in": 3600,
+        }
+        http_client.headers = {"user-agent": "mwlib"}
+
+        ensure_oauth2_token(
+            enabled=True,
+            apiurl="https://example.com/w/api.php",
+            token_info_map=token_info_map,
+            http_client=http_client,
+            logger=MagicMock(),
+            current_time_fn=lambda: 1000,
+        )
+
+        http_client.fetch_token.assert_called_once()
+        assert token_info_map["example.com"]["token"]["access_token"] == "fresh"

--- a/tests/mwlib/network/test_http_client.py
+++ b/tests/mwlib/network/test_http_client.py
@@ -259,12 +259,19 @@ class TestHttpClientManager:
         assert any("oauth2=False" in k for k in keys)
         assert not any("oauth2=True" in k for k in keys)
 
-    def test_get_client_uses_lock_for_concurrent_creation(self, http_client_manager, mock_conf):
-        """Concurrent get_client calls produce one cached client, not duplicates.
+    def test_get_client_serializes_concurrent_creation(self, http_client_manager, mock_conf):
+        """Concurrent ``get_client`` callers must end up with one client, not two.
 
-        Two callers racing on the same cache key must serialize through
-        the lock rather than each constructing a fresh client.
+        We force the race by patching ``create_standard_client`` to wait
+        on a barrier, then spawn two threads that both miss the cache
+        and contend for the lock. The first one through must populate
+        the cache and the second must observe it — without the lock the
+        second thread would also call ``create_standard_client`` and we'd
+        cache duplicates.
         """
+        import threading
+        import time as time_mod
+
         mock_conf.get.side_effect = lambda section, name, default=None, convert=None: {
             ("oauth2", "enabled"): False,
             ("http2", "enabled"): False,
@@ -272,19 +279,104 @@ class TestHttpClientManager:
             ("fetch", "max_connections"): 20,
         }.get((section, name), default)
 
-        # Drive the lock by spinning the cache check ourselves: if the lock
-        # path is correct, only one StandardClient is constructed for the
-        # same cache key even when both threads see an empty cache before
-        # taking the lock.
+        ready = threading.Event()
+        proceed = threading.Event()
+        original_create = http_client_manager.create_standard_client
+
+        def slow_create(*args, **kwargs):
+            ready.set()
+            proceed.wait(timeout=2)
+            return original_create(*args, **kwargs)
+
+        results = []
+
+        def worker():
+            results.append(http_client_manager.get_client("https://example.com"))
+
         with patch.object(
             http_client_manager,
             "create_standard_client",
-            wraps=http_client_manager.create_standard_client,
+            side_effect=slow_create,
         ) as wrapped:
-            c1 = http_client_manager.get_client("https://example.com")
-            c2 = http_client_manager.get_client("https://example.com")
-            assert c1 is c2
-            assert wrapped.call_count == 1
+            t1 = threading.Thread(target=worker)
+            t1.start()
+            ready.wait(timeout=2)  # t1 is inside slow_create, holding the lock
+            t2 = threading.Thread(target=worker)
+            t2.start()
+            time_mod.sleep(0.05)  # let t2 enter get_client and block on the lock
+            proceed.set()
+            t1.join(timeout=2)
+            t2.join(timeout=2)
+
+        assert wrapped.call_count == 1
+        assert len(results) == 2
+        assert results[0] is results[1]
+
+    # ---- Round 4: credential fingerprint in cache key ----
+
+    def test_oauth2_clients_with_different_credentials_get_different_cache_entries(
+        self, http_client_manager, mock_conf
+    ):
+        """Rotating OAuth2 credentials must not silently reuse a stale-cred client.
+
+        Without a credential fingerprint in the cache key, two callers
+        asking for OAuth2 against the same origin with different
+        ``client_id`` / ``client_secret`` would share a cached client
+        configured with the first run's credentials.
+        """
+
+        def conf_with(secret):
+            return lambda section, name, default=None, convert=None: {
+                ("oauth2", "client_id"): "id-A",
+                ("oauth2", "client_secret"): secret,
+                ("oauth2", "token_url"): "https://example.com/token",
+                ("oauth2", "enabled"): True,
+                ("http2", "enabled"): False,
+                ("http2", "auto_detect"): False,
+                ("fetch", "max_connections"): 20,
+            }.get((section, name), default)
+
+        with patch("mwlib.network.http_client.OAuth2Client") as mock_cls:
+            mock_cls.side_effect = lambda **kwargs: MagicMock(spec=[])
+
+            mock_conf.get.side_effect = conf_with("secret-1")
+            c1 = http_client_manager.get_client("https://example.com", use_oauth2=True)
+
+            # Rotate the secret — same origin, same auth choice.
+            mock_conf.get.side_effect = conf_with("secret-2")
+            c2 = http_client_manager.get_client("https://example.com", use_oauth2=True)
+
+        # Different credentials → different cached clients.
+        assert c1 is not c2
+        # The plaintext secret never lands in the cache key.
+        keys = list(http_client_manager._clients.keys())
+        assert all("secret-1" not in k for k in keys)
+        assert all("secret-2" not in k for k in keys)
+        assert any("secret=" in k for k in keys)
+
+    # ---- Round 4: locked singleton ----
+
+    def test_get_instance_is_safe_under_concurrent_first_call(self):
+        """Two threads racing on first ``get_instance`` get the same singleton.
+
+        Without the instance lock, a thread could observe ``_instance is None``
+        between another thread's check and assignment and create a duplicate.
+        """
+        import threading
+
+        HttpClientManager._instance = None
+        results = []
+
+        def worker():
+            results.append(HttpClientManager.get_instance())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=2)
+
+        assert all(r is results[0] for r in results)
 
 
 class TestEnsureOAuth2Token:

--- a/tests/mwlib/network/test_http_client.py
+++ b/tests/mwlib/network/test_http_client.py
@@ -213,6 +213,52 @@ class TestHttpClientManager:
 
         assert client1 is not client2
 
+    def test_invalidate_client_drops_all_oauth_fingerprints_for_origin(
+        self, http_client_manager, mock_conf
+    ):
+        """Invalidate must close every cached OAuth client for the origin.
+
+        Cache keys include a credential fingerprint, so the client
+        cached under the *previous* fingerprint is unreachable through
+        ``_cache_key`` once the credentials have rotated. Without
+        prefix-match invalidation, those rotated-out clients leak
+        forever.
+        """
+
+        def conf_with(secret):
+            return lambda section, name, default=None, convert=None: {
+                ("oauth2", "client_id"): "id-A",
+                ("oauth2", "client_secret"): secret,
+                ("oauth2", "token_url"): "https://example.com/token",
+                ("oauth2", "enabled"): True,
+                ("http2", "enabled"): False,
+                ("http2", "auto_detect"): False,
+                ("fetch", "max_connections"): 20,
+            }.get((section, name), default)
+
+        with patch("mwlib.network.http_client.OAuth2Client") as mock_cls:
+            instances = [MagicMock(), MagicMock()]
+            mock_cls.side_effect = instances
+
+            mock_conf.get.side_effect = conf_with("secret-1")
+            http_client_manager.get_client("https://example.com", use_oauth2=True)
+
+            mock_conf.get.side_effect = conf_with("secret-2")
+            http_client_manager.get_client("https://example.com", use_oauth2=True)
+
+            # Two cached entries before invalidation…
+            assert len(http_client_manager._clients) == 2
+
+            # …and the current-cred caller invalidates BOTH.
+            http_client_manager.invalidate_client(
+                "https://example.com", use_oauth2=True, use_http2=False
+            )
+
+        assert http_client_manager._clients == {}
+        # And we close() every dropped client, not just the current-cred one.
+        for inst in instances:
+            inst.close.assert_called_once()
+
     def test_get_client_normalizes_base_url_by_origin(self, http_client_manager, mock_conf):
         """Clients from the same origin should use a normalized base_url."""
         mock_conf.get.side_effect = lambda section, name, default=None, convert=None: {
@@ -348,11 +394,13 @@ class TestHttpClientManager:
 
         # Different credentials → different cached clients.
         assert c1 is not c2
-        # The plaintext secret never lands in the cache key.
+        # The plaintext credentials never land in the cache key — the
+        # whole OAuth config is hashed into a compact ``auth=...`` field.
         keys = list(http_client_manager._clients.keys())
         assert all("secret-1" not in k for k in keys)
         assert all("secret-2" not in k for k in keys)
-        assert any("secret=" in k for k in keys)
+        assert all("id-A" not in k for k in keys)
+        assert any("auth=" in k for k in keys)
 
     # ---- Round 4: locked singleton ----
 

--- a/tests/mwlib/network/test_sapi.py
+++ b/tests/mwlib/network/test_sapi.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env pytest
 
-"""Unit tests for mwlib.network.sapi module"""
+"""Unit tests for mwlib.network.sapi module."""
 
-import pytest
 from unittest.mock import MagicMock, patch
+
 import httpx
+import pytest
 from pytest_httpx import HTTPXMock
 
-from mwlib.network.sapi import MwApi
 from mwlib.network.http_client import HttpClientManager
+from mwlib.network.sapi import MwApi
 
 
 class TestMwApi:
-    """Tests for the MwApi class"""
+    """Tests for the MwApi class."""
 
     @pytest.fixture
     def reset_http_client_manager(self):
-        """Reset the HttpClientManager singleton before each test"""
+        """Reset the HttpClientManager singleton before each test."""
         HttpClientManager._instance = None
         HttpClientManager._clients = {}
         MwApi._rate_limiters = {}
@@ -33,11 +34,11 @@ class TestMwApi:
 
     @pytest.fixture
     def mw_api(self, reset_http_client_manager):
-        """Create a MwApi instance for testing"""
+        """Create a MwApi instance for testing."""
         return MwApi("https://test.wikipedia.org/w/api.php", use_oauth2=False)
 
     def test_fetch_success(self, mw_api, httpx_mock):
-        """Test successful fetch"""
+        """Test successful fetch."""
         httpx_mock.add_response(text="test data")
         # Call _fetch with a URL
         result = mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query")
@@ -48,9 +49,8 @@ class TestMwApi:
         requests = httpx_mock.get_requests()
         assert requests[0].url == "https://test.wikipedia.org/w/api.php?action=query"
 
-
     def test_fetch_http_429_retry_success(self, mw_api, httpx_mock):
-        """Test retry on HTTP 429 error with eventual success"""
+        """Test retry on HTTP 429 error with eventual success."""
         # Create a response for the 429 error
         httpx_mock.add_response(status_code=429, content="Too Many Requests")
         httpx_mock.add_response(status_code=200, content="test data")
@@ -60,7 +60,9 @@ class TestMwApi:
 
         with patch("mwlib.network.sapi.time.sleep", mock_sleep):
             # Call _fetch with a URL
-            result = mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", max_retries=2)
+            result = mw_api._fetch(
+                "https://test.wikipedia.org/w/api.php?action=query", max_retries=2
+            )
 
             # Verify the result
             assert result == b"test data"
@@ -70,7 +72,7 @@ class TestMwApi:
             mock_sleep.assert_called_with(1)
 
     def test_fetch_http_500_retry_success(self, mw_api, httpx_mock):
-        """Test retry on HTTP 500 error with eventual success"""
+        """Test retry on HTTP 500 error with eventual success."""
         # Create a response for the 500 error
         httpx_mock.add_response(500, content="Internal Server Error")
         httpx_mock.add_response(200, content="test data")
@@ -80,7 +82,9 @@ class TestMwApi:
 
         with patch("mwlib.network.sapi.time.sleep", mock_sleep):
             # Call _fetch with a URL
-            result = mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", max_retries=2)
+            result = mw_api._fetch(
+                "https://test.wikipedia.org/w/api.php?action=query", max_retries=2
+            )
 
             # Verify the result
             assert result == b"test data"
@@ -90,7 +94,7 @@ class TestMwApi:
             mock_sleep.assert_called_with(1)
 
     def test_fetch_url_error_retry_success(self, mw_api, httpx_mock):
-        """Test retry on RequestError with eventual success"""
+        """Test retry on RequestError with eventual success."""
         # Create a success response
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
         httpx_mock.add_response(200, content="test data")
@@ -100,7 +104,9 @@ class TestMwApi:
 
         with patch("mwlib.network.sapi.time.sleep", mock_sleep):
             # Call _fetch with a URL
-            result = mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", max_retries=2)
+            result = mw_api._fetch(
+                "https://test.wikipedia.org/w/api.php?action=query", max_retries=2
+            )
 
             # Verify the result
             assert result == b"test data"
@@ -110,7 +116,7 @@ class TestMwApi:
             mock_sleep.assert_called_with(1)
 
     def test_fetch_http_429_max_retries_exceeded(self, mw_api, httpx_mock):
-        """Test HTTP 429 error with max retries exceeded"""
+        """Test HTTP 429 error with max retries exceeded."""
         # Create a response for the 429 error
         httpx_mock.add_response(429, content="Too Many Requests")
         httpx_mock.add_response(429, content="Too Many Requests")
@@ -135,7 +141,7 @@ class TestMwApi:
             mock_sleep.assert_any_call(2)  # Second retry (1 * 2)
 
     def test_fetch_http_404_no_retry(self, mw_api, httpx_mock):
-        """Test HTTP 404 error with no retry (non-retryable error)"""
+        """Test HTTP 404 error with no retry (non-retryable error)."""
         # Create a response for the 404 error
         httpx_mock.add_response(404, content=b"Not Found")
 
@@ -155,7 +161,7 @@ class TestMwApi:
             assert not mock_sleep.called
 
     def test_fetch_other_exception_no_retry(self, mw_api, httpx_mock):
-        """Test other exception with no retry"""
+        """Test other exception with no retry."""
         # Set up the mock to raise a general exception
         httpx_mock.add_exception(Exception("Test Exception"))
 
@@ -175,7 +181,7 @@ class TestMwApi:
             assert not mock_sleep.called
 
     def test_fetch_exponential_backoff(self, mw_api, httpx_mock):
-        """Test exponential backoff with multiple retries"""
+        """Test exponential backoff with multiple retries."""
         # Create responses for the errors and success
         httpx_mock.add_response(429, content="Too Many Requests")
         httpx_mock.add_response(429, content="Too Many Requests")
@@ -186,8 +192,12 @@ class TestMwApi:
 
         with patch("mwlib.network.sapi.time.sleep", mock_sleep):
             # Call _fetch with a URL
-            result = mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", 
-                                  max_retries=3, initial_delay=2, backoff_factor=3)
+            result = mw_api._fetch(
+                "https://test.wikipedia.org/w/api.php?action=query",
+                max_retries=3,
+                initial_delay=2,
+                backoff_factor=3,
+            )
 
             # Verify the result
             assert result == b"test data"
@@ -198,7 +208,7 @@ class TestMwApi:
             mock_sleep.assert_any_call(6)  # Second retry (initial_delay * backoff_factor)
 
     def test_fetch_with_request_object(self, mw_api, httpx_mock):
-        """Test fetch with a URL string that is not a simple string"""
+        """Test fetch with a URL string that is not a simple string."""
         # Set up the mock to return a successful response
         httpx_mock.add_response(200, content="test data")
 
@@ -221,8 +231,9 @@ class TestMwApi:
 
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep), patch(
-            "mwlib.network.sapi.random.uniform", return_value=2.0
+        with (
+            patch("mwlib.network.sapi.time.sleep", mock_sleep),
+            patch("mwlib.network.sapi.random.uniform", return_value=2.0),
         ):
             mw_api._fetch(
                 "https://test.wikipedia.org/w/api.php?action=query",
@@ -241,8 +252,9 @@ class TestMwApi:
         mw_api.use_oauth2 = True
         mw_api.http_client.fetch_token = MagicMock(side_effect=httpx.ConnectError("token failed"))
 
-        with patch.object(mw_api, "_do_request", return_value={}), patch(
-            "mwlib.network.sapi.time.time", side_effect=[1000, 1000, 1005, 1005]
+        with (
+            patch.object(mw_api, "_do_request", return_value={}),
+            patch("mwlib.network.sapi.time.time", side_effect=[1000, 1000, 1005, 1005]),
         ):
             with pytest.raises(RuntimeError):
                 mw_api.do_request(action="query", meta="siteinfo")
@@ -253,9 +265,10 @@ class TestMwApi:
         assert mw_api._token_info[domain]["next_retry_at"] > 1005
 
     def test_rate_limiter_is_scoped_per_domain(self, mw_api):
-        with patch("mwlib.network.sapi.conf.get", return_value=2), patch(
-            "mwlib.network.sapi.RateLimiter"
-        ) as mock_limiter_cls:
+        with (
+            patch("mwlib.network.sapi.conf.get", return_value=2),
+            patch("mwlib.network.sapi.RateLimiter") as mock_limiter_cls,
+        ):
             limiter_a = MagicMock()
             limiter_b = MagicMock()
             mock_limiter_cls.side_effect = [limiter_a, limiter_b]
@@ -267,3 +280,100 @@ class TestMwApi:
             assert mock_limiter_cls.call_count == 2
             limiter_a.acquire.assert_called()
             limiter_b.acquire.assert_called_once_with()
+
+    def test_rate_limiter_uses_gevent_sleep(self, mw_api):
+        """``RateLimiter.acquire`` must yield to the gevent hub when throttling.
+
+        ``time.sleep`` would block the entire event loop and starve every
+        other greenlet sharing the worker; ``gevent.sleep`` cooperates with
+        the scheduler.
+        """
+        from mwlib.network.sapi import RateLimiter
+
+        rl = RateLimiter(max_calls=1, period=1.0)
+        # Burn the only slot so the next acquire has to wait.
+        rl.acquire()
+
+        with (
+            patch("mwlib.network.sapi.gevent.sleep") as mock_gevent_sleep,
+            patch("mwlib.network.sapi.time.sleep") as mock_time_sleep,
+        ):
+            # Make gevent.sleep advance the clock so the second iteration
+            # of acquire's loop sees an empty window and returns.
+            def advance_clock(_):
+                rl._timestamps.clear()
+
+            mock_gevent_sleep.side_effect = advance_clock
+
+            rl.acquire()
+
+            assert mock_gevent_sleep.called
+            mock_time_sleep.assert_not_called()
+
+    def test_basic_auth_is_per_instance_not_on_shared_client(self, reset_http_client_manager):
+        """Two MwApi instances for the same origin must not share Basic Auth.
+
+        The previous implementation set ``self.http_client.auth = ...`` on
+        the cached httpx client. Since the client is shared between every
+        MwApi for the origin, the second caller would inherit (or
+        overwrite) the first's credentials — a real security issue. Now
+        each MwApi keeps its own ``basic_auth`` and passes it per request.
+        """
+        a = MwApi(
+            "https://en.wikipedia.org/w/api.php",
+            username="alice",
+            password="secret-a",
+            use_oauth2=False,
+        )
+        b = MwApi(
+            "https://en.wikipedia.org/w/api.php",
+            username="bob",
+            password="secret-b",
+            use_oauth2=False,
+        )
+        c = MwApi(
+            "https://en.wikipedia.org/w/api.php",
+            use_oauth2=False,
+        )
+
+        # Same shared client (same origin)…
+        assert a.http_client is b.http_client is c.http_client
+        # …and the shared client was never given an auth attribute.
+        assert getattr(a.http_client, "auth", None) is None
+        # Each MwApi carries its own credentials.
+        assert a.basic_auth is not None
+        assert b.basic_auth is not None
+        assert c.basic_auth is None
+        assert a.basic_auth is not b.basic_auth
+
+    def test_oauth2_fallback_to_standard_disables_use_oauth2(self, reset_http_client_manager):
+        """OAuth2 → standard fallback flips MwApi.use_oauth2 to False.
+
+        When OAuth2 is requested but credentials are missing, the
+        manager hands back a standard httpx.Client. MwApi must recognise
+        that and stop trying to fetch OAuth tokens against it — calling
+        ``fetch_token`` on a non-OAuth2 client crashes with AttributeError.
+        """
+        with patch("mwlib.network.http_client.conf") as mock_conf:
+            mock_conf.get.side_effect = lambda section, name, default=None, convert=None: {
+                ("oauth2", "client_id"): "",
+                ("oauth2", "client_secret"): "",
+                ("http2", "enabled"): False,
+                ("http2", "auto_detect"): False,
+                ("fetch", "max_connections"): 20,
+            }.get((section, name), default)
+            mock_conf.user_agent = "mwlib test"
+
+            api = MwApi("https://example.com/w/api.php", use_oauth2=True)
+
+        # Even though we asked for OAuth2, the manager fell back to a
+        # standard client — and MwApi reflects that.
+        from authlib.integrations.httpx_client import OAuth2Client
+
+        assert api.use_oauth2 is False
+        assert not isinstance(api.http_client, OAuth2Client)
+
+        # do_request → _ensure_oauth2_token → no-op when use_oauth2 is
+        # False. The standard client doesn't even have a fetch_token
+        # method, so the previous behaviour (use_oauth2=True against a
+        # standard client) would have crashed on first request.

--- a/tests/mwlib/network/test_sapi.py
+++ b/tests/mwlib/network/test_sapi.py
@@ -58,7 +58,7 @@ class TestMwApi:
         # Mock time.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL
             result = mw_api._fetch(
                 "https://test.wikipedia.org/w/api.php?action=query", max_retries=2
@@ -80,7 +80,7 @@ class TestMwApi:
         # Mock time.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL
             result = mw_api._fetch(
                 "https://test.wikipedia.org/w/api.php?action=query", max_retries=2
@@ -102,7 +102,7 @@ class TestMwApi:
         # Mock time.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL
             result = mw_api._fetch(
                 "https://test.wikipedia.org/w/api.php?action=query", max_retries=2
@@ -125,7 +125,7 @@ class TestMwApi:
         # Mock time.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL and expect HTTPStatusError
             with pytest.raises(httpx.HTTPStatusError) as excinfo:
                 mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", max_retries=2)
@@ -148,7 +148,7 @@ class TestMwApi:
         # Mock time.sleep to verify it's not called
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL and expect HTTPStatusError
             with pytest.raises(httpx.HTTPStatusError) as excinfo:
                 mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", max_retries=2)
@@ -168,7 +168,7 @@ class TestMwApi:
         # Mock time.sleep to verify it's not called
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL and expect Exception
             with pytest.raises(Exception) as excinfo:
                 mw_api._fetch("https://test.wikipedia.org/w/api.php?action=query", max_retries=2)
@@ -190,7 +190,7 @@ class TestMwApi:
         # Mock time.sleep to verify exponential backoff
         mock_sleep = MagicMock()
 
-        with patch("mwlib.network.sapi.time.sleep", mock_sleep):
+        with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
             # Call _fetch with a URL
             result = mw_api._fetch(
                 "https://test.wikipedia.org/w/api.php?action=query",
@@ -232,7 +232,7 @@ class TestMwApi:
         mock_sleep = MagicMock()
 
         with (
-            patch("mwlib.network.sapi.time.sleep", mock_sleep),
+            patch("mwlib.network.sapi.gevent.sleep", mock_sleep),
             patch("mwlib.network.sapi.random.uniform", return_value=2.0),
         ):
             mw_api._fetch(
@@ -261,8 +261,10 @@ class TestMwApi:
             mw_api.do_request(action="query", meta="siteinfo")
 
         assert mw_api.http_client.fetch_token.call_count == 1
-        domain = "test.wikipedia.org"
-        assert mw_api._token_info[domain]["next_retry_at"] > 1005
+        # Token state is keyed by the OAuth identity, not just domain, so
+        # two configurations against the same wiki don't share tokens.
+        token_key = mw_api._oauth_token_cache_key()
+        assert mw_api._token_info[token_key]["next_retry_at"] > 1005
 
     def test_rate_limiter_is_scoped_per_domain(self, mw_api):
         with (
@@ -345,6 +347,48 @@ class TestMwApi:
         assert b.basic_auth is not None
         assert c.basic_auth is None
         assert a.basic_auth is not b.basic_auth
+
+    def test_retry_backoff_uses_gevent_sleep(self, mw_api, httpx_mock):
+        """Retry backoff must yield to gevent, not block the hub.
+
+        ``RateLimiter.acquire`` already uses ``gevent.sleep``; retries
+        used to still go through ``time.sleep``, which would starve
+        every other greenlet during a 429 storm.
+        """
+        httpx_mock.add_response(429, content="Too Many Requests")
+        httpx_mock.add_response(200, content="ok")
+
+        with (
+            patch("mwlib.network.sapi.gevent.sleep") as mock_gevent_sleep,
+            patch("mwlib.network.sapi.time.sleep") as mock_time_sleep,
+        ):
+            mw_api._fetch(
+                "https://test.wikipedia.org/w/api.php?action=query",
+                max_retries=2,
+            )
+
+            assert mock_gevent_sleep.called
+            mock_time_sleep.assert_not_called()
+
+    def test_oauth_token_cache_key_includes_client_identity(self, mw_api):
+        """Different OAuth client identities yield different token cache keys.
+
+        Token state used to be keyed by domain alone — credential
+        rotation or multi-tenant runs would silently reuse each other's
+        access tokens. The new key folds in client_id and token_endpoint.
+        """
+        # Inject distinct OAuth identities onto the http client mock.
+        mw_api.http_client = MagicMock()
+        mw_api.http_client.client_id = "tenant-a"
+        mw_api.http_client.token_endpoint = "https://wiki/oauth"
+        key_a = mw_api._oauth_token_cache_key()
+
+        mw_api.http_client.client_id = "tenant-b"
+        key_b = mw_api._oauth_token_cache_key()
+
+        assert key_a != key_b
+        assert "tenant-a" in key_a
+        assert "tenant-b" in key_b
 
     def test_oauth2_fallback_to_standard_disables_use_oauth2(self, reset_http_client_manager):
         """OAuth2 → standard fallback flips MwApi.use_oauth2 to False.

--- a/tests/mwlib/network/test_sapi.py
+++ b/tests/mwlib/network/test_sapi.py
@@ -17,20 +17,23 @@ class TestMwApi:
 
     @pytest.fixture
     def reset_http_client_manager(self):
-        """Reset the HttpClientManager singleton before each test."""
+        """Reset shared singletons / class state before each test.
+
+        ``request_counter`` lives on the instance now, so it doesn't need
+        a class-level reset — but the cached HTTP clients, rate limiters,
+        and OAuth token state are class-shared and must be cleared.
+        """
         HttpClientManager._instance = None
         HttpClientManager._clients = {}
         MwApi._rate_limiters = {}
         MwApi._rate_limiter_rps = {}
         MwApi._token_info = {}
-        MwApi.request_counter = 0
         yield
         HttpClientManager._instance = None
         HttpClientManager._clients = {}
         MwApi._rate_limiters = {}
         MwApi._rate_limiter_rps = {}
         MwApi._token_info = {}
-        MwApi.request_counter = 0
 
     @pytest.fixture
     def mw_api(self, reset_http_client_manager):
@@ -55,7 +58,7 @@ class TestMwApi:
         httpx_mock.add_response(status_code=429, content="Too Many Requests")
         httpx_mock.add_response(status_code=200, content="test data")
 
-        # Mock time.sleep to avoid waiting during tests
+        # Mock gevent.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -77,7 +80,7 @@ class TestMwApi:
         httpx_mock.add_response(500, content="Internal Server Error")
         httpx_mock.add_response(200, content="test data")
 
-        # Mock time.sleep to avoid waiting during tests
+        # Mock gevent.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -99,7 +102,7 @@ class TestMwApi:
         httpx_mock.add_exception(httpx.ConnectError("Connection refused"))
         httpx_mock.add_response(200, content="test data")
 
-        # Mock time.sleep to avoid waiting during tests
+        # Mock gevent.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -122,7 +125,7 @@ class TestMwApi:
         httpx_mock.add_response(429, content="Too Many Requests")
         httpx_mock.add_response(429, content="Too Many Requests")
 
-        # Mock time.sleep to avoid waiting during tests
+        # Mock gevent.sleep to avoid waiting during tests
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -145,7 +148,7 @@ class TestMwApi:
         # Create a response for the 404 error
         httpx_mock.add_response(404, content=b"Not Found")
 
-        # Mock time.sleep to verify it's not called
+        # Mock gevent.sleep to verify it's not called
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -165,7 +168,7 @@ class TestMwApi:
         # Set up the mock to raise a general exception
         httpx_mock.add_exception(Exception("Test Exception"))
 
-        # Mock time.sleep to verify it's not called
+        # Mock gevent.sleep to verify it's not called
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -187,7 +190,7 @@ class TestMwApi:
         httpx_mock.add_response(429, content="Too Many Requests")
         httpx_mock.add_response(200, content="test data")
 
-        # Mock time.sleep to verify exponential backoff
+        # Mock gevent.sleep to verify exponential backoff
         mock_sleep = MagicMock()
 
         with patch("mwlib.network.sapi.gevent.sleep", mock_sleep):
@@ -312,6 +315,32 @@ class TestMwApi:
             assert mock_gevent_sleep.called
             mock_time_sleep.assert_not_called()
 
+    def test_request_counter_is_per_instance(self, reset_http_client_manager):
+        """Two MwApis must not share a request counter.
+
+        ``self.request_counter`` used to read the class-level default
+        until first incremented, then silently shadow it on the
+        instance. Two MwApis would race on the class attribute up to
+        their first request and then diverge. Now it's plainly
+        per-instance from construction.
+        """
+        a = MwApi("https://a.wikipedia.org/w/api.php", use_oauth2=False, use_http2=False)
+        b = MwApi("https://b.wikipedia.org/w/api.php", use_oauth2=False, use_http2=False)
+
+        # Both start at 0, both as instance attributes (no class-level shadowing).
+        assert a.request_counter == 0
+        assert b.request_counter == 0
+        assert "request_counter" in a.__dict__
+        assert "request_counter" in b.__dict__
+
+        # Mimic what _handle_request does — bump the counter — without
+        # actually firing HTTP. This is what the regression is about: the
+        # increment used to write to a class attribute on first call.
+        a.request_counter += 1
+
+        assert a.request_counter == 1
+        assert b.request_counter == 0
+
     def test_basic_auth_is_per_instance_not_on_shared_client(self, reset_http_client_manager):
         """Two MwApi instances for the same origin must not share Basic Auth.
 
@@ -371,24 +400,39 @@ class TestMwApi:
             mock_time_sleep.assert_not_called()
 
     def test_oauth_token_cache_key_includes_client_identity(self, mw_api):
-        """Different OAuth client identities yield different token cache keys.
+        """Different OAuth identities yield different token cache keys.
 
         Token state used to be keyed by domain alone — credential
         rotation or multi-tenant runs would silently reuse each other's
-        access tokens. The new key folds in client_id and token_endpoint.
+        access tokens. The new key folds in the full OAuth config
+        fingerprint (client_id + secret + token_url, hashed).
         """
-        # Inject distinct OAuth identities onto the http client mock.
-        mw_api.http_client = MagicMock()
-        mw_api.http_client.client_id = "tenant-a"
-        mw_api.http_client.token_endpoint = "https://wiki/oauth"
-        key_a = mw_api._oauth_token_cache_key()
 
-        mw_api.http_client.client_id = "tenant-b"
-        key_b = mw_api._oauth_token_cache_key()
+        def conf_with(client_id, secret):
+            return lambda section, name, default=None, convert=None: {
+                ("oauth2", "client_id"): client_id,
+                ("oauth2", "client_secret"): secret,
+                ("oauth2", "token_url"): "https://wiki/oauth",
+            }.get((section, name), default)
+
+        with patch("mwlib.network.http_client.conf") as mock_conf:
+            mock_conf.get.side_effect = conf_with("tenant-a", "secret-a")
+            key_a = mw_api._oauth_token_cache_key()
+
+            # Same client_id + token_url, different secret → still distinct.
+            mock_conf.get.side_effect = conf_with("tenant-a", "secret-b")
+            key_secret_rotated = mw_api._oauth_token_cache_key()
+
+            mock_conf.get.side_effect = conf_with("tenant-b", "secret-a")
+            key_b = mw_api._oauth_token_cache_key()
 
         assert key_a != key_b
-        assert "tenant-a" in key_a
-        assert "tenant-b" in key_b
+        # Secret rotation alone is enough to flip the key (this is the
+        # round-5 fix — the previous key only used client_id).
+        assert key_a != key_secret_rotated
+        # Plaintext credentials never end up in the key.
+        assert "tenant-a" not in key_a
+        assert "secret-a" not in key_a
 
     def test_oauth2_fallback_to_standard_disables_use_oauth2(self, reset_http_client_manager):
         """OAuth2 → standard fallback flips MwApi.use_oauth2 to False.

--- a/uv.lock
+++ b/uv.lock
@@ -263,6 +263,116 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274 },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.50.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495 },
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-resumable-media" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/13/6515c7aab55a4a0cf708ffd309fb9af5bab54c13e32dc22c5acd6497193c/google_cloud_bigquery-3.41.0.tar.gz", hash = "sha256:2217e488b47ed576360c9b2cc07d59d883a54b83167c0ef37f915c26b01a06fe", size = 513434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/33/1d3902efadef9194566d499d61507e1f038454e0b55499d2d7f8ab2a4fee/google_cloud_bigquery-3.41.0-py3-none-any.whl", hash = "sha256:2a5b5a737b401cbd824a6e5eac7554100b878668d908e6548836b5d8aaa4dcaa", size = 262343 },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/24/6ca08b0a03c7b0c620427503ab00353a4ae806b848b93bcea18b6b76fde6/google_cloud_core-2.5.1.tar.gz", hash = "sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811", size = 36078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d9/5bb050cb32826466aa9b25f79e2ca2879fe66cb76782d4ed798dd7506151/google_cloud_core-2.5.1-py3-none-any.whl", hash = "sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7", size = 29452 },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298 },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872 },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243 },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608 },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439 },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300 },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867 },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364 },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740 },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437 },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615 },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800 },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/d1/b1ea14b93b6b78f57fc580125de44e9f593ab88dd2460f1a8a8d18f74754/google_resumable_media-2.8.2.tar.gz", hash = "sha256:f3354a182ebd193ae3f42e3ef95e6c9b10f128320de23ac7637236713b1acd70", size = 2164510 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f8/50bfaf4658431ff9de45c5c3935af7ab01157a4903c603cd0eee6e78e087/google_resumable_media-2.8.2-py3-none-any.whl", hash = "sha256:82b6d8ccd11765268cdd2a2123f417ec806b8eef3000a9a38dfe3033da5fb220", size = 81511 },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743 },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -286,6 +396,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190 },
     { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055 },
     { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817 },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/db/1d56e5f5823257b291962d6c0ce106146c6447f405b60b234c4f222a7cde/grpcio-1.80.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:dfab85db094068ff42e2a3563f60ab3dddcc9d6488a35abf0132daec13209c8a", size = 6055009 },
+    { url = "https://files.pythonhosted.org/packages/6e/18/c83f3cad64c5ca63bca7e91e5e46b0d026afc5af9d0a9972472ceba294b3/grpcio-1.80.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5c07e82e822e1161354e32da2662f741a4944ea955f9f580ec8fb409dd6f6060", size = 12035295 },
+    { url = "https://files.pythonhosted.org/packages/0f/8e/e14966b435be2dda99fbe89db9525ea436edc79780431a1c2875a3582644/grpcio-1.80.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba0915d51fd4ced2db5ff719f84e270afe0e2d4c45a7bdb1e8d036e4502928c2", size = 6610297 },
+    { url = "https://files.pythonhosted.org/packages/cc/26/d5eb38f42ce0e3fdc8174ea4d52036ef8d58cc4426cb800f2610f625dd75/grpcio-1.80.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3cb8130ba457d2aa09fa6b7c3ed6b6e4e6a2685fce63cb803d479576c4d80e21", size = 7300208 },
+    { url = "https://files.pythonhosted.org/packages/25/51/bd267c989f85a17a5b3eea65a6feb4ff672af41ca614e5a0279cc0ea381c/grpcio-1.80.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09e5e478b3d14afd23f12e49e8b44c8684ac3c5f08561c43a5b9691c54d136ab", size = 6813442 },
+    { url = "https://files.pythonhosted.org/packages/9e/d9/d80eef735b19e9169e30164bbf889b46f9df9127598a83d174eb13a48b26/grpcio-1.80.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:00168469238b022500e486c1c33916acf2f2a9b2c022202cf8a1885d2e3073c1", size = 7414743 },
+    { url = "https://files.pythonhosted.org/packages/de/f2/567f5bd5054398ed6b0509b9a30900376dcf2786bd936812098808b49d8d/grpcio-1.80.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8502122a3cc1714038e39a0b071acb1207ca7844208d5ea0d091317555ee7106", size = 8426046 },
+    { url = "https://files.pythonhosted.org/packages/62/29/73ef0141b4732ff5eacd68430ff2512a65c004696997f70476a83e548e7e/grpcio-1.80.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ce1794f4ea6cc3ca29463f42d665c32ba1b964b48958a66497917fe9069f26e6", size = 7851641 },
+    { url = "https://files.pythonhosted.org/packages/46/69/abbfa360eb229a8623bab5f5a4f8105e445bd38ce81a89514ba55d281ad0/grpcio-1.80.0-cp311-cp311-win32.whl", hash = "sha256:51b4a7189b0bef2aa30adce3c78f09c83526cf3dddb24c6a96555e3b97340440", size = 4154368 },
+    { url = "https://files.pythonhosted.org/packages/6f/d4/ae92206d01183b08613e846076115f5ac5991bae358d2a749fa864da5699/grpcio-1.80.0-cp311-cp311-win_amd64.whl", hash = "sha256:02e64bb0bb2da14d947a49e6f120a75e947250aebe65f9629b62bb1f5c14e6e9", size = 4894235 },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616 },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204 },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866 },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060 },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121 },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811 },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860 },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132 },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904 },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944 },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638 },
 ]
 
 [[package]]
@@ -435,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "mwlib"
-version = "0.18.1"
+version = "0.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "apipkg" },
@@ -455,6 +610,7 @@ dependencies = [
     { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "reportlab" },
+    { name = "requests" },
     { name = "roman" },
     { name = "simplejson" },
     { name = "sqlitedict" },
@@ -462,8 +618,14 @@ dependencies = [
     { name = "toml" },
 ]
 
+[package.optional-dependencies]
+bigquery = [
+    { name = "google-cloud-bigquery" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "google-cloud-bigquery" },
     { name = "pytest" },
     { name = "pytest-httpx" },
     { name = "pytest-xdist" },
@@ -478,6 +640,7 @@ requires-dist = [
     { name = "click" },
     { name = "cython" },
     { name = "gevent" },
+    { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.0" },
     { name = "httpx", extras = ["http2"] },
     { name = "lxml" },
     { name = "mwclient" },
@@ -489,6 +652,7 @@ requires-dist = [
     { name = "pypdf" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "reportlab" },
+    { name = "requests" },
     { name = "roman" },
     { name = "simplejson" },
     { name = "sqlitedict" },
@@ -498,6 +662,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "google-cloud-bigquery", specifier = ">=3.0" },
     { name = "pytest" },
     { name = "pytest-httpx", specifier = ">=0.35.0" },
     { name = "pytest-xdist" },
@@ -578,12 +743,60 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450 },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739 },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089 },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737 },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610 },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381 },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436 },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656 },
+]
+
+[[package]]
 name = "py"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708 },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997 },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
 ]
 
 [[package]]
@@ -662,6 +875,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/dc/865845cfe987b21658e871d16e0a24e871e00884c545f246dd8f6f69edda/pytest_xdist-3.7.0.tar.gz", hash = "sha256:f9248c99a7c15b7d2f90715df93610353a485827bc06eefb6566d23f6400f126", size = 87550 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/b2/0e802fde6f1c5b2f7ae7e9ad42b83fd4ecebac18a8a8c2f2f14e39dce6e1/pytest_xdist-3.7.0-py3-none-any.whl", hash = "sha256:7d3fbd255998265052435eb9daa4e99b62e6fb9cfb6efd1f858d4d8c0c7f0ca0", size = 46142 },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -590,7 +590,7 @@ wheels = [
 
 [[package]]
 name = "mwlib"
-version = "0.18.2"
+version = "0.18.3"
 source = { editable = "." }
 dependencies = [
     { name = "apipkg" },


### PR DESCRIPTION
## Summary

- Adds a BigQuery-first lookup path for image description pages on configured Wikipedia domains, with the `wme-ingest` CLI that loads Wikimedia Enterprise namespace snapshots into BigQuery.
- Routes around Action API rate limits for license/template/contributor metadata while preserving the remote-API path for non-BigQuery wikis and for cache misses.
- Extends `wme-ingest` to also sync namespace-0 article HTML, the data source the pre-order page-count estimator depends on.
- Folds in seven rounds of code-review fixes — every security, correctness, and ergonomic concern raised during review is addressed in the commit history.

## What's in scope

### BigQuery image lookup (NS6, runtime)

- `mwlib.network.bigquery_lookup` — singleton-managed BigQuery client, hostname-exact domain routing, identifier validation before SQL interpolation, exact-match row filtering, credential-fingerprinted cache keys.
- `mwlib.network.fetch.Fetcher` — BigQuery batch flush, deferred-image-download accounting, contributor-attribution fallback to `authors.db`, BQ-eligibility check hoisted above the remote api/siteinfo so a flaky remote can't kill a working cache hit.
- `mwlib.network.sapi.MwApi` — per-instance Basic Auth, OAuth token cache keyed by full credential fingerprint, gevent-cooperative rate limiting and retry backoff.
- `mwlib.network.http_client.HttpClientManager` — locked singleton + locked client cache, OAuth credential check resolved before cache-key construction, prefix-match `invalidate_client` so credential rotations can clear out stale entries.
- `mwlib.rendering.licensechecker` — public `decide_from_template_names` helper so fetch-time and render-time policy stay in lockstep.

### `wme-ingest` (NS6 + NS0, ETL)

- Multi-namespace dispatch via `--namespace {0,6}` (default 6). Per-namespace `NamespaceConfig` carries the snapshot id, target table, schema, parser, and table-management policy.
- **NS6 → `file_pages`**: image description metadata for license checking — script-managed table (drop + recreate on each run, preserves the legacy behaviour).
- **NS0 → `article_pages`**: lean Parsoid HTML schema (`name`, `identifier`, `date_modified`, `article_body_html`) sized to keep BigQuery storage proportional to what the page-count estimator actually consumes. Wikitext, abstracts, templates, version metadata and other WME fields are dropped at ingest time. Table is provisioned externally (Pulumi), so the script never drops it.
- **Disk hygiene for NS0**: NDJSON members are extracted from the tarball one at a time and unlinked before the next is extracted, capping peak local disk at "tarball + at most one extracted NDJSON" rather than "tarball + every NDJSON".
- **Load-job streaming**: each NDJSON file is submitted as its own BigQuery load job (WRITE_TRUNCATE on the first, WRITE_APPEND afterwards), so a single multi-hundred-GB intermediate file is never required.

### Packaging

- `pyproject.toml` — `google-cloud-bigquery` is an optional extra (`pip install mwlib[bigquery]`); default installs stay slim. `requests` declared explicitly.
- `MANIFEST.in` — ships the new modules in sdists.

## Fail-closed surfaces (security-relevant)

- Tar extraction rejects non-regular members (symlinks, hardlinks, devices) and streams via `shutil.copyfileobj` instead of `tar.extract`. Path traversal and absolute paths are rejected up front.
- Malformed BigQuery `templates` data raises `BqTemplatesError` and is rerouted to the remote-API fallback. Empty/partial template lists no longer pass blacklist mode.
- BigQuery misses with no remote-API fallback drop the deferred image download instead of fetching an image with no license/attribution data.
- BigQuery identifier validation errors propagate from `fetch_batch` instead of being papered over as a transient outage.
- Basic Auth no longer mutates the shared `httpx.Client`; credentials don't leak across `MwApi` instances sharing an origin.
- OAuth token cache and HTTP client cache both fingerprint the full OAuth config, so credential rotation produces a fresh client and fresh token state.
- Domain matching in BigQuery routing and license-policy detection both compare parsed hostnames exactly — lookalike URLs can't substring-match their way past either gate.

## External dependencies

- The `article_pages` BigQuery table referenced by NS0 ingestion is provisioned in the pediapress repo (clustered on `name`, deletion-protected). Tracked separately on the `feat/slice-5-bigquery-ns0-sync` branch — that infra needs to land before NS0 sync runs in production.

## Test plan

- [ ] Targeted unit tests pass: `uv run pytest tests/mwlib/network/test_bigquery_lookup.py tests/mwlib/network/test_fetch.py tests/mwlib/network/test_http_client.py tests/mwlib/network/test_sapi.py tests/mwlib/apps/test_fetch_wikimedia_snapshot.py`
- [ ] Full mwlib unit suite passes: `uv run pytest tests/mwlib --ignore=tests/mwlib/integration`
- [ ] `wme-ingest --list` returns snapshots against a real WME account.
- [ ] `wme-ingest --namespace 6 --download-only` produces an NS6 tarball that loads cleanly via `wme-ingest --namespace 6 -i <tarball>`.
- [ ] `wme-ingest --namespace 0 --download-only` produces an NS0 tarball; `wme-ingest --namespace 0 -i <tarball>` loads it into the (Pulumi-provisioned) `article_pages` table.
- [ ] During NS0 load, only one extracted NDJSON file is on disk at a time (verify by spot-checking `ls` against the temp dir during the run).
- [ ] End-to-end: a render against `en.wikipedia.org` with `bigquery.enabled=true` skips description-page fetches for images present in the NS6 snapshot, and falls back to the Action API for images not in BigQuery.
- [ ] License filtering at fetch time matches render-time decisions on a sample of images (free / nonfree / unknown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)