### PR TITLE
Add release.yml for PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: Publish to PyPI
+
+# Triggered by a published GitHub release (the canonical path) or by
+# manual dispatch (so we can retroactively publish a release that was
+# created before this workflow existed, e.g. 0.18.3).
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (defaults to the workflow's checkout)"
+        required: false
+        default: ""
+
+# Trusted Publisher / OIDC: pypa/gh-action-pypi-publish exchanges the
+# GitHub-issued OIDC token for a short-lived PyPI upload token, so no
+# long-lived API token has to live in a GitHub secret.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Default to the tag/release ref; allow overriding via
+          # workflow_dispatch input for retro-publishes.
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Build sdist
+        # Sdist only — this project has C extensions and we don't run
+        # cibuildwheel, so a single-platform wheel would mislead pip on
+        # other platforms. Consumers build from sdist; the pre-generated
+        # .c files (committed in src/) make this fast and compiler-driven.
+        run: uv build --sdist
+
+      - name: Verify version matches the tag
+        # On a release trigger, github.ref_name is the tag (e.g. "0.18.3").
+        # Refuse to publish a sdist whose version doesn't match — guards
+        # against a forgotten pyproject.toml bump.
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          # Strip an optional leading "v" so both "0.18.3" and "v0.18.3"
+          # tag styles work.
+          expected="${tag#v}"
+          actual=$(python3 -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Tag $tag does not match pyproject version $actual"
+            exit 1
+          fi
+          echo "Tag $tag matches pyproject version $actual"
+
+      - name: Upload sdist as artifact
+        # Keep a copy on the workflow run so post-mortem inspection of
+        # what was published is one click away.
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # The Trusted Publisher entry on PyPI may pin to a specific
+    # environment. Add ``environment: pypi`` here if the PyPI side
+    # requires it (Settings → Publishing → "Environment name").
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # No password / api token: OIDC via Trusted Publishers.
+          packages-dir: dist
+          # Keep this on for the first run so a duplicate upload (e.g.
+          # re-running the workflow after a partial failure) doesn't
+          # blow up. Once we trust the pipeline this can be flipped off.
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,11 @@ on:
 
 # Trusted Publisher / OIDC: pypa/gh-action-pypi-publish exchanges the
 # GitHub-issued OIDC token for a short-lived PyPI upload token, so no
-# long-lived API token has to live in a GitHub secret.
+# long-lived API token has to live in a GitHub secret. The id-token
+# permission is scoped to the publish job below — the build job has
+# no business minting OIDC tokens.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
@@ -49,16 +50,26 @@ jobs:
 
       - name: Verify version matches the tag
         # On a release trigger, github.ref_name is the tag (e.g. "0.18.3").
-        # Refuse to publish a sdist whose version doesn't match — guards
-        # against a forgotten pyproject.toml bump.
-        if: github.event_name == 'release'
+        # On workflow_dispatch with a version-shaped ref, treat it the
+        # same way — catches "typed 0.18.4 by mistake" before the
+        # irreversible PyPI upload. Non-version refs (a SHA or branch)
+        # skip the check.
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.ref != '')
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${GITHUB_REF_NAME}"
+          else
+            tag="${{ inputs.ref }}"
+          fi
           # Strip an optional leading "v" so both "0.18.3" and "v0.18.3"
           # tag styles work.
           expected="${tag#v}"
-          actual=$(python3 -c 'import tomllib,sys; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
+          if ! [[ "$expected" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9.]+)?$ ]]; then
+            echo "Ref '$tag' is not a version-shaped tag; skipping version check."
+            exit 0
+          fi
+          actual=$(python3 -c 'import tomllib; print(tomllib.load(open("pyproject.toml","rb"))["project"]["version"])')
           if [ "$expected" != "$actual" ]; then
             echo "::error::Tag $tag does not match pyproject version $actual"
             exit 1
@@ -78,9 +89,16 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-    # The Trusted Publisher entry on PyPI may pin to a specific
-    # environment. Add ``environment: pypi`` here if the PyPI side
-    # requires it (Settings → Publishing → "Environment name").
+    permissions:
+      # OIDC token for Trusted Publishers — only the publish job needs it.
+      id-token: write
+    # The matching Trusted Publisher entry on PyPI must be configured
+    # with Environment name = "pypi". Using a GitHub Environment here
+    # also lets us add required reviewers / branch protections in
+    # Settings → Environments → pypi as a manual gate before upload.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mwlib
     steps:
       - name: Download sdist
         uses: actions/download-artifact@v4
@@ -89,7 +107,11 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to a SHA rather than the floating ``release/v1`` branch:
+        # this action mints the OIDC->PyPI token, so a hijacked tag
+        # would mean a hijacked publisher. Bump intentionally.
+        # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           # No password / api token: OIDC via Trusted Publishers.
           packages-dir: dist


### PR DESCRIPTION
## Summary

Wires up the PyPI Trusted Publisher / OIDC flow so releases publish to PyPI without a long-lived API token in repo secrets.

### Triggers

- **`release: published`** — canonical path. A new GitHub release fires the upload.
- **`workflow_dispatch`** with an optional `ref` input — covers retro-publishes (e.g. publishing **0.18.3**, whose release was created before this workflow existed).

### Build

`uv build --sdist` only. The project has C extensions and we don't run cibuildwheel, so a single-platform wheel built in CI would mislead pip on every other platform. Consumers compile from sdist; the pre-generated `.c` files in `src/` make that fast.

### Safety / least privilege

- `id-token: write` is **scoped to the `publish` job only** — the build job has no business minting OIDC tokens.
- `pypa/gh-action-pypi-publish` is **pinned to commit SHA** (`cef221092ed1...` = v1.14.0) rather than the floating `release/v1`. This action is the OIDC→PyPI trust boundary; a hijacked tag would mean a hijacked publisher.
- Tag-vs-pyproject version check runs on both `release` and `workflow_dispatch` (when ref is version-shaped) — catches a forgotten `version =` bump or a typo'd `ref=0.18.4` before the irreversible upload.
- `skip-existing: true` on the publish step so a re-run after a partial failure doesn't break.
- Publish job runs in a GitHub `pypi` Environment, which gives you a knob in Settings → Environments → pypi to require manual approval / restrict to certain branches as an extra gate.

## What you need to verify on the PyPI side

The Trusted Publisher entry at https://pypi.org/manage/project/mwlib/settings/publishing/ must have:

| Field | Value |
| --- | --- |
| Owner | `pediapress` |
| Repository name | `mwlib` |
| Workflow name | `release.yml` |
| **Environment name** | **`pypi`** |

The Environment name is now required (the workflow's `publish` job runs in `environment: pypi`). If your existing PyPI config left it blank, set it to `pypi`.

## How to publish 0.18.3 retroactively

After this PR merges:

1. **Actions** tab → **Publish to PyPI** → **Run workflow**.
2. Set **ref** to `0.18.3` (the existing tag).
3. Run.

The version check confirms `0.18.3` matches `pyproject.toml`, then `uv build --sdist` produces `mwlib-0.18.3.tar.gz` and the publish job uploads it to PyPI via OIDC.

## Test plan

- [ ] PR merges to main.
- [ ] PyPI Trusted Publisher Environment name is set to `pypi`.
- [ ] `workflow_dispatch` with `ref=0.18.3` succeeds and `mwlib-0.18.3` appears on https://pypi.org/project/mwlib/.
- [ ] Next time we cut a release on GitHub, the `release: published` trigger fires and publishes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)