### PR TITLE
Bump release.yml JS actions to Node 24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+# Keeps GitHub Actions up to date so the next "Node X is deprecated"
+# announcement doesn't catch a release scheduled the same week.
+#
+# - Floating major-tag actions (checkout, setup-python, setup-uv) get
+#   batched into one PR per cycle — they're routine bumps.
+# - SHA-pinned actions (artifact upload/download, the PyPI publisher)
+#   get individual PRs by default; that's correct because each one
+#   crosses the trust boundary and warrants its own review of the
+#   release notes / diff.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      ci-actions:
+        patterns:
+          - "actions/checkout"
+          - "actions/setup-*"
+          - "astral-sh/setup-uv"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,16 @@
 name: Publish to PyPI
 
+# Pinning policy:
+# - Actions inside the build → publish trust boundary (artifact transport
+#   and the publisher itself) are pinned to immutable commit SHAs. A
+#   hijacked tag on those would let an attacker swap the sdist payload
+#   or impersonate the publisher; SHA pins make every bump intentional.
+# - Other actions (checkout, language/tool setup) float on a major-version
+#   tag. Dependabot keeps them current — see ``.github/dependabot.yml``.
+# - Each Node-based action is pinned to a version whose ``action.yml``
+#   declares ``runs.using: node24`` so the workflow survives GitHub's
+#   2026-06-02 removal of the Node 20 runtime.
+#
 # Triggered by a published GitHub release (the canonical path) or by
 # manual dispatch (so we can retroactively publish a release that was
 # created before this workflow existed, e.g. 0.18.3).
@@ -27,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Default to the tag/release ref; allow overriding via
           # workflow_dispatch input for retro-publishes.
@@ -39,7 +50,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Build sdist
         # Sdist only — this project has C extensions and we don't run
@@ -77,9 +88,12 @@ jobs:
           echo "Tag $tag matches pyproject version $actual"
 
       - name: Upload sdist as artifact
-        # Keep a copy on the workflow run so post-mortem inspection of
-        # what was published is one click away.
-        uses: actions/upload-artifact@v5
+        # Inside the trust boundary — pinned to commit SHA so a hijacked
+        # tag can't swap the sdist payload before the publisher uploads
+        # it. Keep a copy on the workflow run so post-mortem inspection
+        # of what was published is one click away.
+        # v7.0.1 (Node 24)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -101,16 +115,22 @@ jobs:
       url: https://pypi.org/p/mwlib
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v5
+        # Inside the trust boundary — see the upload-artifact pin
+        # rationale in the build job.
+        # v8.0.1 (Node 24)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: sdist
           path: dist
 
       - name: Publish to PyPI
         # Pinned to a SHA rather than the floating ``release/v1`` branch:
-        # this action mints the OIDC->PyPI token, so a hijacked tag
-        # would mean a hijacked publisher. Bump intentionally.
-        # v1.14.0
+        # this action mints the OIDC→PyPI token, so a hijacked tag would
+        # mean a hijacked publisher. Bump intentionally.
+        #
+        # v1.14.0 — composite action (no ``runs.using: node*`` of its own;
+        # invokes Docker + Python sub-actions internally), so it's not
+        # affected by the Node 20 runner deprecation.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           # No password / api token: OIDC via Trusted Publishers.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Default to the tag/release ref; allow overriding via
           # workflow_dispatch input for retro-publishes.
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: Build sdist
         # Sdist only — this project has C extensions and we don't run
@@ -79,7 +79,7 @@ jobs:
       - name: Upload sdist as artifact
         # Keep a copy on the workflow run so post-mortem inspection of
         # what was published is one click away.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -101,7 +101,7 @@ jobs:
       url: https://pypi.org/p/mwlib
     steps:
       - name: Download sdist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: sdist
           path: dist


### PR DESCRIPTION
## Summary

The 0.18.3 publish run succeeded, but it emitted:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/download-artifact@v4`. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

This PR bumps every Node-based action in `release.yml` to a version whose `action.yml` declares `runs.using: node24`, so the next release survives the cutoff. It also tightens the trust boundary and adds Dependabot for future bumps — see "Self-review fixes" below.

## Pin table

| Action | Before | After | Pin style | Runtime (verified) |
| --- | --- | --- | --- | --- |
| `actions/checkout` | v4 | **v6** | floating major | node24 |
| `actions/setup-python` | v5 | **v6** | floating major | node24 |
| `astral-sh/setup-uv` | v3 | **v7** | floating major | node24 |
| `actions/upload-artifact` | v4 | **v7.0.1** | **SHA pin** | node24 |
| `actions/download-artifact` | v4 | **v8.0.1** | **SHA pin** | node24 |
| `pypa/gh-action-pypi-publish` | (already SHA-pinned, v1.14.0) | unchanged | SHA pin | composite (Node-deprecation N/A) |

Each runtime was verified by fetching `action.yml` at the pinned ref:

```bash
gh api '/repos/<owner>/<repo>/contents/action.yml?ref=<sha>' --jq .content | base64 -d | grep using
```

## Pinning policy (now documented at the top of the file)

- **Inside the build → publish trust boundary** (artifact transport + the publisher itself): pin to commit SHA. A hijacked tag here could swap the sdist or impersonate the publisher.
- **Outside the trust boundary** (checkout, language/tool setup): float on a major. Dependabot keeps them current.

## Self-review fixes folded into this PR

- **Original bumps to `upload-artifact@v5` / `download-artifact@v5` were still on Node 20.** Verified via `action.yml`. Corrected to v7.0.1 / v8.0.1, both Node 24.
- **Artifact transport now SHA-pinned.** Same trust-boundary logic that justified pinning `pypa/gh-action-pypi-publish` applies here — a hijacked tag on `upload-artifact` could swap the sdist before the SHA-pinned publisher takes over.
- **`pypa/gh-action-pypi-publish` is composite, not Node** — its comment now says so, so future readers don't worry about it being on Node 20.
- **Added `.github/dependabot.yml`** for monthly grouped bumps of the floating-tag actions. SHA-pinned actions get individual PRs (each one crosses the trust boundary).

## Test plan

- [ ] PR merges to main.
- [ ] Next release fires the workflow without any Node 20 deprecation warning.
- [ ] Dependabot opens its first grouped action-bump PR within ~30 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)